### PR TITLE
Make File Filter Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ensure that a Markdown file's created date is synchronised with the created-at d
 
 ## Usage
 
-Execute FmSync passing a path to a directory which contains files you wish to recursively scan. For any Markdown (*.md) files found, the file's created date will be updated to match that of the `created` date found in the file's Front Matter where one exists.
+Execute FmSync passing a path to a directory which contains files you wish to recursively scan. For any Markdown files found, the file's created date will be updated to match that of the `created` date found in the file's Front Matter where one exists.
 
 ```powershell
 fmsync c:\my-markdownfiles
@@ -30,4 +30,8 @@ This contains a single setting, `TimeZoneId`, which by default is empty. When th
 Alternatively, `TimeZoneId` can be set to any time zone as specified in the `Timezone` column of [this documentation](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/default-time-zones). FmSync will then use this timezone when setting the created date on a file.
 
 If the date given in a file's Front Matter contains a time offset, the TimeZoneId given here will be ignored and the offset given will be taken into account when setting the created date on a file.
+
+### FileSystemOptions
+
+This contains a single setting, `FilenamePattern`, which by default is `*.md`. Only files matching this filter will be acted upon by FmSync.
 

--- a/src/Elzik.FmSync.Application/Elzik.FmSync.Application.csproj
+++ b/src/Elzik.FmSync.Application/Elzik.FmSync.Application.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.52.0.60960">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -22,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elzik.FmSync.Domain\Elzik.FmSync.Domain.csproj" />
+    <ProjectReference Include="..\Elzik.FmSync.Infrastructure\Elzik.FmSync.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Elzik.FmSync.Console/Presentation/Program.cs
+++ b/src/Elzik.FmSync.Console/Presentation/Program.cs
@@ -17,6 +17,7 @@ var host = Host.CreateDefaultBuilder(args)
         services.AddTransient<IFrontMatterFileSynchroniser, FrontMatterFileSynchroniser>();
         services.AddTransient<IFrontMatterFolderSynchroniser, FrontMatterFolderSynchroniser>();
         services.Configure<FrontMatterOptions>(context.Configuration.GetSection("FrontMatterOptions"));
+        services.Configure<FileSystemOptions>(context.Configuration.GetSection("FileSystemOptions"));
         services.AddLogging(loggingBuilder =>
         {
             loggingBuilder.AddConfiguration(context.Configuration.GetSection("Logging"));

--- a/src/Elzik.FmSync.Console/appSettings.json
+++ b/src/Elzik.FmSync.Console/appSettings.json
@@ -12,5 +12,8 @@
   },
   "FrontMatterOptions": {
     "TimeZoneId": ""
-  }
+  },
+  "FileSystemOptions": {
+    "FilenamePattern": "*.md" 
+  } 
 }

--- a/src/Elzik.FmSync.Infrastructure/FileSystemOptions.cs
+++ b/src/Elzik.FmSync.Infrastructure/FileSystemOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Elzik.FmSync.Infrastructure;
+
+public class FileSystemOptions
+{
+    public string FilenamePattern { get; set; }
+}

--- a/src/Elzik.FmSync.Infrastructure/FrontMatterOptions.cs
+++ b/src/Elzik.FmSync.Infrastructure/FrontMatterOptions.cs
@@ -1,7 +1,6 @@
-﻿namespace Elzik.FmSync.Infrastructure
+﻿namespace Elzik.FmSync.Infrastructure;
+
+public class FrontMatterOptions
 {
-    public class FrontMatterOptions
-    {
-        public string? TimeZoneId { get; set; }
-    }
+    public string? TimeZoneId { get; set; }
 }

--- a/tests/Elzik.FmSync.Application.Tests.Unit/FrontMatterFileSynchroniserTests.cs
+++ b/tests/Elzik.FmSync.Application.Tests.Unit/FrontMatterFileSynchroniserTests.cs
@@ -6,134 +6,133 @@ using NSubstitute.ReturnsExtensions;
 using Thinktecture.IO;
 using Xunit;
 
-namespace Elzik.FmSync.Application.Tests.Unit
+namespace Elzik.FmSync.Application.Tests.Unit;
+
+public class FrontMatterFileSynchroniserTests
 {
-    public class FrontMatterFileSynchroniserTests
+    private readonly Fixture _fixture;
+    private readonly MockLogger<FrontMatterFileSynchroniser> _mockLogger;
+    private readonly IMarkdownFrontMatter _mockMarkDownFrontMatter;
+    private readonly IFile _mockFile;
+    private readonly FrontMatterFileSynchroniser _frontMatterFileSynchroniser;
+
+    public FrontMatterFileSynchroniserTests()
     {
-        private readonly Fixture _fixture;
-        private readonly MockLogger<FrontMatterFileSynchroniser> _mockLogger;
-        private readonly IMarkdownFrontMatter _mockMarkDownFrontMatter;
-        private readonly IFile _mockFile;
-        private readonly FrontMatterFileSynchroniser _frontMatterFileSynchroniser;
+        _mockMarkDownFrontMatter = Substitute.For<IMarkdownFrontMatter>();
+        _mockFile = Substitute.For<IFile>();
+        _mockLogger = Substitute.For<MockLogger<FrontMatterFileSynchroniser>>();
 
-        public FrontMatterFileSynchroniserTests()
-        {
-            _mockMarkDownFrontMatter = Substitute.For<IMarkdownFrontMatter>();
-            _mockFile = Substitute.For<IFile>();
-            _mockLogger = Substitute.For<MockLogger<FrontMatterFileSynchroniser>>();
+        _fixture = new Fixture();
+        _fixture.Register<ILogger<FrontMatterFileSynchroniser>>(() => _mockLogger);
+        _fixture.Register(() => _mockMarkDownFrontMatter);
+        _fixture.Register(() => _mockFile);
+        _frontMatterFileSynchroniser = _fixture.Create<FrontMatterFileSynchroniser>();
+    }
 
-            _fixture = new Fixture();
-            _fixture.Register<ILogger<FrontMatterFileSynchroniser>>(() => _mockLogger);
-            _fixture.Register(() => _mockMarkDownFrontMatter);
-            _fixture.Register(() => _mockFile);
-            _frontMatterFileSynchroniser = _fixture.Create<FrontMatterFileSynchroniser>();
-        }
+    [Fact]
+    public void SyncCreationDates_NoMarkDownCreationDate_OnlyLogs()
+    {
+        // Arrange
+        var testFilePath = _fixture.Create<string>();
+        _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).ReturnsNull();
 
-        [Fact]
-        public void SyncCreationDates_NoMarkDownCreationDate_OnlyLogs()
-        {
-            // Arrange
-            var testFilePath = _fixture.Create<string>();
-            _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).ReturnsNull();
+        // Act
+        _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
 
-            // Act
-            _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Information, 
+            $"{testFilePath} has no Front Matter created date.");
+        _mockFile.DidNotReceiveWithAnyArgs().SetCreationTimeUtc(default!, default);
+    }
 
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Information, 
-                $"{testFilePath} has no Front Matter created date.");
-            _mockFile.DidNotReceiveWithAnyArgs().SetCreationTimeUtc(default!, default);
-        }
+    [Fact]
+    public void SyncCreationDates_MarkDownAndFileDateEqual_OnlyLogs()
+    {
+        // Arrange
+        var testFilePath = _fixture.Create<string>();
+        var testDate = _fixture.Create<DateTime>();
+        _mockFile.GetCreationTimeUtc(testFilePath).Returns(testDate);
+        _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testDate);
 
-        [Fact]
-        public void SyncCreationDates_MarkDownAndFileDateEqual_OnlyLogs()
-        {
-            // Arrange
-            var testFilePath = _fixture.Create<string>();
-            var testDate = _fixture.Create<DateTime>();
-            _mockFile.GetCreationTimeUtc(testFilePath).Returns(testDate);
-            _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testDate);
+        // Act
+        _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
 
-            // Act
-            _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
+        // Assert
+        _mockLogger.Received(1).Log(
+            LogLevel.Information,
+            Arg.Is<IDictionary<string, object>>(
+                dict =>
+                    dict.Any(kv => kv.Key == "{OriginalFormat}" 
+                                   && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) " +
+                                   "the same as the created date specified in its Front Matter.") &&
+                    dict.Any(kv => kv.Key == "FilePath" 
+                                   && (string)kv.Value == testFilePath) &&
+                    dict.Any(kv => kv.Key == "FileCreatedDate" 
+                                   && (DateTime)kv.Value == testDate)));
+        _mockFile.DidNotReceiveWithAnyArgs().SetCreationTimeUtc(default!, default);
+    }
 
-            // Assert
-            _mockLogger.Received(1).Log(
-                LogLevel.Information,
-                Arg.Is<IDictionary<string, object>>(
-                    dict =>
-                        dict.Any(kv => kv.Key == "{OriginalFormat}" 
-                                       && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) " +
-                                       "the same as the created date specified in its Front Matter.") &&
-                        dict.Any(kv => kv.Key == "FilePath" 
-                                       && (string)kv.Value == testFilePath) &&
-                        dict.Any(kv => kv.Key == "FileCreatedDate" 
-                                       && (DateTime)kv.Value == testDate)));
-            _mockFile.DidNotReceiveWithAnyArgs().SetCreationTimeUtc(default!, default);
-        }
+    [Fact]
+    public void SyncCreationDates_FileDateLaterThanMarkdownDate_LogsAndUpdates()
+    {
+        // Arrange
+        var testFilePath = _fixture.Create<string>();
+        var testMarkDownDate = _fixture.Create<DateTime>();
+        var testFileDate = testMarkDownDate.AddTicks(_fixture.Create<long>());
+        _mockFile.GetCreationTimeUtc(testFilePath).Returns(testFileDate);
+        _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testMarkDownDate);
 
-        [Fact]
-        public void SyncCreationDates_FileDateLaterThanMarkdownDate_LogsAndUpdates()
-        {
-            // Arrange
-            var testFilePath = _fixture.Create<string>();
-            var testMarkDownDate = _fixture.Create<DateTime>();
-            var testFileDate = testMarkDownDate.AddTicks(_fixture.Create<long>());
-            _mockFile.GetCreationTimeUtc(testFilePath).Returns(testFileDate);
-            _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testMarkDownDate);
+        // Act
+        _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
 
-            // Act
-            _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
+        // Assert
+        _mockLogger.Received(1).Log(
+            LogLevel.Information,
+            Arg.Is<IDictionary<string, object>>(
+                dict =>
+                    dict.Any(kv => kv.Key == "{OriginalFormat}"
+                                   && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) {RelativeDescription} " +
+                                   "than the created date specified in its Front Matter ({FrontMatterCreatedDate})") &&
+                    dict.Any(kv => kv.Key == "FilePath"
+                                   && (string)kv.Value == testFilePath) &&
+                    dict.Any(kv => kv.Key == "FileCreatedDate"
+                                   && (DateTime)kv.Value == testFileDate) &&
+                    dict.Any(kv => kv.Key == "RelativeDescription"
+                                   && (string)kv.Value == "later") &&
+                    dict.Any(kv => kv.Key == "FrontMatterCreatedDate"
+                                   && (DateTime)kv.Value == testMarkDownDate)));
+        _mockFile.Received(1).SetCreationTimeUtc(testFilePath, testMarkDownDate);
+    }
 
-            // Assert
-            _mockLogger.Received(1).Log(
-                LogLevel.Information,
-                Arg.Is<IDictionary<string, object>>(
-                    dict =>
-                        dict.Any(kv => kv.Key == "{OriginalFormat}"
-                                       && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) {RelativeDescription} " +
-                                       "than the created date specified in its Front Matter ({FrontMatterCreatedDate})") &&
-                        dict.Any(kv => kv.Key == "FilePath"
-                                       && (string)kv.Value == testFilePath) &&
-                        dict.Any(kv => kv.Key == "FileCreatedDate"
-                                       && (DateTime)kv.Value == testFileDate) &&
-                        dict.Any(kv => kv.Key == "RelativeDescription"
-                                       && (string)kv.Value == "later") &&
-                        dict.Any(kv => kv.Key == "FrontMatterCreatedDate"
-                                       && (DateTime)kv.Value == testMarkDownDate)));
-            _mockFile.Received(1).SetCreationTimeUtc(testFilePath, testMarkDownDate);
-        }
+    [Fact]
+    public void SyncCreationDates_FileDateEarlierThanMarkdownDate_LogsAndUpdates()
+    {
+        // Arrange
+        var testFilePath = _fixture.Create<string>();
+        var testMarkDownDate = _fixture.Create<DateTime>();
+        var testFileDate = testMarkDownDate.Subtract(_fixture.Create<TimeSpan>());
+        _mockFile.GetCreationTimeUtc(testFilePath).Returns(testFileDate);
+        _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testMarkDownDate);
 
-        [Fact]
-        public void SyncCreationDates_FileDateEarlierThanMarkdownDate_LogsAndUpdates()
-        {
-            // Arrange
-            var testFilePath = _fixture.Create<string>();
-            var testMarkDownDate = _fixture.Create<DateTime>();
-            var testFileDate = testMarkDownDate.Subtract(_fixture.Create<TimeSpan>());
-            _mockFile.GetCreationTimeUtc(testFilePath).Returns(testFileDate);
-            _mockMarkDownFrontMatter.GetCreatedDateUtc(testFilePath).Returns(testMarkDownDate);
+        // Act
+        _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
 
-            // Act
-            _frontMatterFileSynchroniser.SyncCreationDate(testFilePath);
-
-            // Assert
-            _mockLogger.Received(1).Log(
-                LogLevel.Information,
-                Arg.Is<IDictionary<string, object>>(
-                    dict =>
-                        dict.Any(kv => kv.Key == "{OriginalFormat}"
-                                       && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) {RelativeDescription} " +
-                                       "than the created date specified in its Front Matter ({FrontMatterCreatedDate})") &&
-                        dict.Any(kv => kv.Key == "FilePath"
-                                       && (string)kv.Value == testFilePath) &&
-                        dict.Any(kv => kv.Key == "FileCreatedDate"
-                                       && (DateTime)kv.Value == testFileDate) &&
-                        dict.Any(kv => kv.Key == "RelativeDescription"
-                                       && (string)kv.Value == "earlier") &&
-                        dict.Any(kv => kv.Key == "FrontMatterCreatedDate"
-                                       && (DateTime)kv.Value == testMarkDownDate)));
-            _mockFile.Received(1).SetCreationTimeUtc(testFilePath, testMarkDownDate);
-        }
+        // Assert
+        _mockLogger.Received(1).Log(
+            LogLevel.Information,
+            Arg.Is<IDictionary<string, object>>(
+                dict =>
+                    dict.Any(kv => kv.Key == "{OriginalFormat}"
+                                   && (string)kv.Value == "{FilePath} has a file created date ({FileCreatedDate}) {RelativeDescription} " +
+                                   "than the created date specified in its Front Matter ({FrontMatterCreatedDate})") &&
+                    dict.Any(kv => kv.Key == "FilePath"
+                                   && (string)kv.Value == testFilePath) &&
+                    dict.Any(kv => kv.Key == "FileCreatedDate"
+                                   && (DateTime)kv.Value == testFileDate) &&
+                    dict.Any(kv => kv.Key == "RelativeDescription"
+                                   && (string)kv.Value == "earlier") &&
+                    dict.Any(kv => kv.Key == "FrontMatterCreatedDate"
+                                   && (DateTime)kv.Value == testMarkDownDate)));
+        _mockFile.Received(1).SetCreationTimeUtc(testFilePath, testMarkDownDate);
     }
 }

--- a/tests/Elzik.FmSync.Application.Tests.Unit/FrontMatterFolderSynchroniserTests.cs
+++ b/tests/Elzik.FmSync.Application.Tests.Unit/FrontMatterFolderSynchroniserTests.cs
@@ -6,173 +6,172 @@ using NSubstitute.ExceptionExtensions;
 using Thinktecture.IO;
 using Xunit;
 
-namespace Elzik.FmSync.Application.Tests.Unit
+namespace Elzik.FmSync.Application.Tests.Unit;
+
+public class FrontMatterFolderSynchroniserTests
 {
-    public class FrontMatterFolderSynchroniserTests
+    private readonly Fixture _fixture;
+    private readonly MockLogger<FrontMatterFolderSynchroniser> _mockLogger;
+    private readonly IDirectory _mockDirectory;
+    private readonly IFrontMatterFileSynchroniser _mockFileSynchroniser;
+    private readonly FrontMatterFolderSynchroniser _frontMatterFolderSynchroniser;
+
+
+    public FrontMatterFolderSynchroniserTests()
     {
-        private readonly Fixture _fixture;
-        private readonly MockLogger<FrontMatterFolderSynchroniser> _mockLogger;
-        private readonly IDirectory _mockDirectory;
-        private readonly IFrontMatterFileSynchroniser _mockFileSynchroniser;
-        private readonly FrontMatterFolderSynchroniser _frontMatterFolderSynchroniser;
+        _mockLogger = Substitute.For<MockLogger<FrontMatterFolderSynchroniser>>();
+        _mockDirectory = Substitute.For<IDirectory>();
+        _mockFileSynchroniser = Substitute.For<IFrontMatterFileSynchroniser>();
 
+        _fixture = new Fixture();
+        _fixture.Register<ILogger<FrontMatterFolderSynchroniser>>(() => _mockLogger);
+        _fixture.Register(() => _mockDirectory);
+        _fixture.Register(() => _mockFileSynchroniser);
+        _frontMatterFolderSynchroniser = _fixture.Create<FrontMatterFolderSynchroniser>();
+    }
 
-        public FrontMatterFolderSynchroniserTests()
-        {
-            _mockLogger = Substitute.For<MockLogger<FrontMatterFolderSynchroniser>>();
-            _mockDirectory = Substitute.For<IDirectory>();
-            _mockFileSynchroniser = Substitute.For<IFrontMatterFileSynchroniser>();
-
-            _fixture = new Fixture();
-            _fixture.Register<ILogger<FrontMatterFolderSynchroniser>>(() => _mockLogger);
-            _fixture.Register(() => _mockDirectory);
-            _fixture.Register(() => _mockFileSynchroniser);
-            _frontMatterFolderSynchroniser = _fixture.Create<FrontMatterFolderSynchroniser>();
-        }
-
-        [Fact]
-        public void SyncCreationDates_DirectoryPathSupplied_OnlyLogs()
-        {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
+    [Fact]
+    public void SyncCreationDates_DirectoryPathSupplied_OnlyLogs()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
             
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
 
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Information, $"Synchronising files in {testDirectoryPath}");
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Information, $"Synchronising files in {testDirectoryPath}");
 
-            _mockFileSynchroniser.DidNotReceiveWithAnyArgs().SyncCreationDate(default!);
-        }
+        _mockFileSynchroniser.DidNotReceiveWithAnyArgs().SyncCreationDate(default!);
+    }
 
-        [Fact]
-        public void SyncCreationDates_NoMarkDownFiles_OnlyLogs()
+    [Fact]
+    public void SyncCreationDates_NoMarkDownFiles_OnlyLogs()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
+            s.StartsWith("Synchronised 0 files out of a total 0 in")));
+        _mockFileSynchroniser.DidNotReceiveWithAnyArgs().SyncCreationDate(default!);
+    }
+
+    [Fact]
+    public void SyncCreationDates_WithMarkDownFiles_SyncsThoseFiles()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+        var testFiles = _fixture.CreateMany<KeyValuePair<string, bool>>().ToList();
+        SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+
+        // Assert
+        _mockFileSynchroniser.ReceivedWithAnyArgs(testFiles.Count).SyncCreationDate(default!);
+        foreach (var testFilesPath in testFiles)
         {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
-
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
-                s.StartsWith("Synchronised 0 files out of a total 0 in")));
-            _mockFileSynchroniser.DidNotReceiveWithAnyArgs().SyncCreationDate(default!);
+            _mockFileSynchroniser.Received(1).SyncCreationDate(testFilesPath.Key);
         }
+    }
 
-        [Fact]
-        public void SyncCreationDates_WithMarkDownFiles_SyncsThoseFiles()
+    [Fact]
+    public void SyncCreationDates_WithMarkDownFiles_LogsSummary()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+        var testFiles = _fixture.CreateMany<KeyValuePair<string, bool>>().ToList();
+        SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
+            s.StartsWith($"Synchronised {testFiles.Count(pair => pair.Value)} files out of a total {testFiles.Count} in")));
+    }
+
+    [Fact]
+    public void SyncCreationDates_SyncFailsWithInnerException_LogsError()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+        var testFile = _fixture.Create<KeyValuePair<string, bool>>();
+        var testFiles = new List<KeyValuePair<string, bool>> { testFile };
+        SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+        var testException = new Exception(_fixture.Create<string>(), _fixture.Create<Exception>());
+        _mockFileSynchroniser.SyncCreationDate(testFile.Key).Throws(testException);
+
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+
+        // Assert
+        _mockLogger.Received(1).Log( LogLevel.Error, 
+            testFile.Key + " - " + testException.Message + " " + testException.InnerException?.Message);
+    }
+
+    [Fact]
+    public void SyncCreationDates_SyncFailsWithoutInnerException_LogsError()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+        var testFile = _fixture.Create<KeyValuePair<string, bool>>();
+        var testFiles = new List<KeyValuePair<string, bool>> { testFile };
+        SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+        var testException = new Exception(_fixture.Create<string>());
+        _mockFileSynchroniser.SyncCreationDate(testFile.Key).Throws(testException);
+
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Error,
+            testFile.Key + " - " + testException.Message);
+    }
+
+    [Fact]
+    public void SyncCreationDates_SyncFails_LogsSummary()
+    {
+        // Arrange
+        var testDirectoryPath = _fixture.Create<string>();
+        var testFailingFile = new KeyValuePair<string, bool>(_fixture.Create<string>(), false);
+        var testFiles = new []
         {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-            var testFiles = _fixture.CreateMany<KeyValuePair<string, bool>>().ToList();
-            SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+            testFailingFile,
+            new (_fixture.Create<string>(), false),
+            new (_fixture.Create<string>(), true)
+        };
+        SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
+        var testException = new Exception(_fixture.Create<string>(), _fixture.Create<Exception>());
+        _mockFileSynchroniser.SyncCreationDate(testFailingFile.Key).Throws(testException);
 
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
+        // Act
+        _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
 
-            // Assert
-            _mockFileSynchroniser.ReceivedWithAnyArgs(testFiles.Count).SyncCreationDate(default!);
-            foreach (var testFilesPath in testFiles)
+        // Assert
+        _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
+            s.StartsWith("Synchronised 1 and failed 1 files out of a total 3 in")));
+    }
+
+    private void SetMockDirectoryFilePaths(string testDirectoryPath, IEnumerable<KeyValuePair<string, bool>> testFiles)
+    {
+        var testFileList = testFiles.ToList();
+
+        _mockDirectory.EnumerateFiles(testDirectoryPath, "*.md",
+                Arg.Is<EnumerationOptions>(options =>
+                    options.MatchCasing == MatchCasing.CaseInsensitive && options.RecurseSubdirectories))
+            .Returns(testFileList.Select(pair => pair.Key));
+
+        foreach (var testFilePath in testFileList)
+        {
+            _mockFileSynchroniser.SyncCreationDate(testFilePath.Key).Returns(new SyncResult
             {
-                _mockFileSynchroniser.Received(1).SyncCreationDate(testFilesPath.Key);
-            }
-        }
-
-        [Fact]
-        public void SyncCreationDates_WithMarkDownFiles_LogsSummary()
-        {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-            var testFiles = _fixture.CreateMany<KeyValuePair<string, bool>>().ToList();
-            SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
-
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
-
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
-                s.StartsWith($"Synchronised {testFiles.Count(pair => pair.Value)} files out of a total {testFiles.Count} in")));
-        }
-
-        [Fact]
-        public void SyncCreationDates_SyncFailsWithInnerException_LogsError()
-        {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-            var testFile = _fixture.Create<KeyValuePair<string, bool>>();
-            var testFiles = new List<KeyValuePair<string, bool>> { testFile };
-            SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
-            var testException = new Exception(_fixture.Create<string>(), _fixture.Create<Exception>());
-            _mockFileSynchroniser.SyncCreationDate(testFile.Key).Throws(testException);
-
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
-
-            // Assert
-            _mockLogger.Received(1).Log( LogLevel.Error, 
-                testFile.Key + " - " + testException.Message + " " + testException.InnerException?.Message);
-        }
-
-        [Fact]
-        public void SyncCreationDates_SyncFailsWithoutInnerException_LogsError()
-        {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-            var testFile = _fixture.Create<KeyValuePair<string, bool>>();
-            var testFiles = new List<KeyValuePair<string, bool>> { testFile };
-            SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
-            var testException = new Exception(_fixture.Create<string>());
-            _mockFileSynchroniser.SyncCreationDate(testFile.Key).Throws(testException);
-
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
-
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Error,
-                testFile.Key + " - " + testException.Message);
-        }
-
-        [Fact]
-        public void SyncCreationDates_SyncFails_LogsSummary()
-        {
-            // Arrange
-            var testDirectoryPath = _fixture.Create<string>();
-            var testFailingFile = new KeyValuePair<string, bool>(_fixture.Create<string>(), false);
-            var testFiles = new []
-            {
-                testFailingFile,
-                new (_fixture.Create<string>(), false),
-                new (_fixture.Create<string>(), true)
-            };
-            SetMockDirectoryFilePaths(testDirectoryPath, testFiles);
-            var testException = new Exception(_fixture.Create<string>(), _fixture.Create<Exception>());
-            _mockFileSynchroniser.SyncCreationDate(testFailingFile.Key).Throws(testException);
-
-            // Act
-            _frontMatterFolderSynchroniser.SyncCreationDates(testDirectoryPath);
-
-            // Assert
-            _mockLogger.Received(1).Log(LogLevel.Information, Arg.Is<string>(s =>
-                s.StartsWith("Synchronised 1 and failed 1 files out of a total 3 in")));
-        }
-
-        private void SetMockDirectoryFilePaths(string testDirectoryPath, IEnumerable<KeyValuePair<string, bool>> testFiles)
-        {
-            var testFileList = testFiles.ToList();
-
-            _mockDirectory.EnumerateFiles(testDirectoryPath, "*.md",
-                    Arg.Is<EnumerationOptions>(options =>
-                        options.MatchCasing == MatchCasing.CaseInsensitive && options.RecurseSubdirectories))
-                .Returns(testFileList.Select(pair => pair.Key));
-
-            foreach (var testFilePath in testFileList)
-            {
-                _mockFileSynchroniser.SyncCreationDate(testFilePath.Key).Returns(new SyncResult
-                {
-                    FileCreatedDateUpdated = testFilePath.Value
-                });
-            }
+                FileCreatedDateUpdated = testFilePath.Value
+            });
         }
     }
 }

--- a/tests/Elzik.FmSync.Application.Tests.Unit/MockLogger.cs
+++ b/tests/Elzik.FmSync.Application.Tests.Unit/MockLogger.cs
@@ -1,39 +1,38 @@
-﻿namespace Elzik.FmSync.Application.Tests.Unit
+﻿namespace Elzik.FmSync.Application.Tests.Unit;
+
+using Microsoft.Extensions.Logging;
+
+// This class is necessary because mocking an ILogger will not work; further explanation here:
+// https://github.com/nsubstitute/NSubstitute/issues/597#issuecomment-1081422618
+
+public abstract class MockLogger<T> : ILogger<T>
 {
-    using Microsoft.Extensions.Logging;
-
-    // This class is necessary because mocking an ILogger will not work; further explanation here:
-    // https://github.com/nsubstitute/NSubstitute/issues/597#issuecomment-1081422618
-
-    public abstract class MockLogger<T> : ILogger<T>
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, 
+        Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, 
-            Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-            var unboxed = (IReadOnlyList<KeyValuePair<string, object>>)state!;
-            var message = formatter(state, exception);
+        var unboxed = (IReadOnlyList<KeyValuePair<string, object>>)state!;
+        var message = formatter(state, exception);
 
-            Log();
-            Log(logLevel, message);
-            Log(logLevel, message, exception);
-            Log(logLevel, unboxed.ToDictionary(k =>
-                k.Key, v => v.Value));
-            Log(logLevel, unboxed.ToDictionary(k => 
-                k.Key, v => v.Value), exception);
-        }
-
-        public abstract void Log();
-
-        public abstract void Log(LogLevel logLevel, string message);
-
-        public abstract void Log(LogLevel logLevel, string message, Exception? exception);
-
-        public abstract void Log(LogLevel logLevel, IDictionary<string, object> state);
-
-        public abstract void Log(LogLevel logLevel, IDictionary<string, object> state, Exception? exception);
-
-        public virtual bool IsEnabled(LogLevel logLevel) => true;
-
-        public abstract IDisposable? BeginScope<TState>(TState state) where TState : notnull;
+        Log();
+        Log(logLevel, message);
+        Log(logLevel, message, exception);
+        Log(logLevel, unboxed.ToDictionary(k =>
+            k.Key, v => v.Value));
+        Log(logLevel, unboxed.ToDictionary(k => 
+            k.Key, v => v.Value), exception);
     }
+
+    public abstract void Log();
+
+    public abstract void Log(LogLevel logLevel, string message);
+
+    public abstract void Log(LogLevel logLevel, string message, Exception? exception);
+
+    public abstract void Log(LogLevel logLevel, IDictionary<string, object> state);
+
+    public abstract void Log(LogLevel logLevel, IDictionary<string, object> state, Exception? exception);
+
+    public virtual bool IsEnabled(LogLevel logLevel) => true;
+
+    public abstract IDisposable? BeginScope<TState>(TState state) where TState : notnull;
 }

--- a/tests/Elzik.FmSync.Infrastructure.Tests.Integration/MarkdownFrontMatterTests.cs
+++ b/tests/Elzik.FmSync.Infrastructure.Tests.Integration/MarkdownFrontMatterTests.cs
@@ -5,129 +5,128 @@ using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Elzik.FmSync.Infrastructure.Tests.Integration
+namespace Elzik.FmSync.Infrastructure.Tests.Integration;
+
+public sealed class MarkdownFrontMatterTests : IDisposable
 {
-    public sealed class MarkdownFrontMatterTests : IDisposable
+    [Theory]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "GMT Standard Time", null, "2023-01-07 14:28:22", 
+        "because the current timezone is GMT")]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "GMT Standard Time", null, "2023-01-07 14:28:22", 
+        "because the current timezone is GMT")]
+    [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "GMT Standard Time", null, "2022-03-31 13:52:15", 
+        "because the current timezone is GMT at BST")]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "AUS Eastern Standard Time", null, "2023-01-07 03:28:22", 
+        "because the current timezone is AUS")]
+    [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "AUS Eastern Standard Time", null, "2022-03-31 03:52:15", 
+        "because the current timezone is AUS")]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "AUS Eastern Standard Time", null, "2023-01-07 03:28:22", 
+        "because the current timezone is AUS")]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-01-07 03:28:22", 
+        "because even though the current timezone is GMT the YAML is configured for AUS")]
+    [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "GMT Standard Time", "AUS Eastern Standard Time", "2022-03-31 03:52:15", 
+        "because even though the current timezone is GMT the YAML is configured for AUS")]
+    [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-01-07 03:28:22", 
+        "because even though the current timezone is GMT the YAML is configured for AUS")]
+    [InlineData("./TestFiles/YamlContainsOnlyDateWithOffset.md", "GMT Standard Time", null, "2023-02-14 13:20:32", 
+        "because even though our current timezone is GMT it is ignored because a time offset was supplied in the Front Matter data")]
+    [InlineData("./TestFiles/YamlContainsOnlyDateWithOffset.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-02-14 13:20:32", 
+        "because even though our current timezone is GMT and the Front Matter is configured for AUS they are both ignored because a time offset was supplied in the Front Matter data")]
+    public void GetCreatedDate_YamlContainsCreatedDate_ReturnsCreatedDate(string testFilePath, string localTimeZone, 
+        string configuredTimeZone, string expectedUtcDateString, string because)
     {
-        [Theory]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "GMT Standard Time", null, "2023-01-07 14:28:22", 
-            "because the current timezone is GMT")]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "GMT Standard Time", null, "2023-01-07 14:28:22", 
-            "because the current timezone is GMT")]
-        [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "GMT Standard Time", null, "2022-03-31 13:52:15", 
-            "because the current timezone is GMT at BST")]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "AUS Eastern Standard Time", null, "2023-01-07 03:28:22", 
-            "because the current timezone is AUS")]
-        [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "AUS Eastern Standard Time", null, "2022-03-31 03:52:15", 
-            "because the current timezone is AUS")]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "AUS Eastern Standard Time", null, "2023-01-07 03:28:22", 
-            "because the current timezone is AUS")]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDate.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-01-07 03:28:22", 
-            "because even though the current timezone is GMT the YAML is configured for AUS")]
-        [InlineData("./TestFiles/YamlContainsCreatedDateAndOtherValue.md", "GMT Standard Time", "AUS Eastern Standard Time", "2022-03-31 03:52:15", 
-            "because even though the current timezone is GMT the YAML is configured for AUS")]
-        [InlineData("./TestFiles/YamlContainsOnlyCreatedDateWithPrecedingNewLines.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-01-07 03:28:22", 
-            "because even though the current timezone is GMT the YAML is configured for AUS")]
-        [InlineData("./TestFiles/YamlContainsOnlyDateWithOffset.md", "GMT Standard Time", null, "2023-02-14 13:20:32", 
-            "because even though our current timezone is GMT it is ignored because a time offset was supplied in the Front Matter data")]
-        [InlineData("./TestFiles/YamlContainsOnlyDateWithOffset.md", "GMT Standard Time", "AUS Eastern Standard Time", "2023-02-14 13:20:32", 
-            "because even though our current timezone is GMT and the Front Matter is configured for AUS they are both ignored because a time offset was supplied in the Front Matter data")]
-        public void GetCreatedDate_YamlContainsCreatedDate_ReturnsCreatedDate(string testFilePath, string localTimeZone, 
-            string configuredTimeZone, string expectedUtcDateString, string because)
+        // Arrange
+        SetTimeZone(localTimeZone);
+        var testOptions = Options.Create(new FrontMatterOptions
         {
-            // Arrange
-            SetTimeZone(localTimeZone);
-            var testOptions = Options.Create(new FrontMatterOptions
-            {
-                TimeZoneId = configuredTimeZone
-            });
-            var expectedDateUtc = DateTime.ParseExact(expectedUtcDateString, "yyyy-MM-dd HH:mm:ss",
-                CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            TimeZoneId = configuredTimeZone
+        });
+        var expectedDateUtc = DateTime.ParseExact(expectedUtcDateString, "yyyy-MM-dd HH:mm:ss",
+            CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
-            // Act
-            var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
-            var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
+        // Act
+        var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
+        var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
 
-            // Assert
-            createdDate.Should().Be(expectedDateUtc, because);
-            createdDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
-        }
+        // Assert
+        createdDate.Should().Be(expectedDateUtc, because);
+        createdDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
 
-        [Theory]
-        [InlineData("./TestFiles/YamlIsEmpty.md")]
-        [InlineData("./TestFiles/YamlContainsOnlyWhitespace.md")]
-        [InlineData("./TestFiles/YamlContainsOnlyNonCreatedDate.md")]
-        [InlineData("./TestFiles/YamlIsMissingBodyIsPresent.md")]
-        [InlineData("./TestFiles/YamlSectionNeverClosed.md")]
-        [InlineData("./TestFiles/YamlSectionNeverOpened.md")]
-        [InlineData("./TestFiles/TextPrecedesYamlSection.md")]
-        [InlineData("./TestFiles/WhitespacePrecedesYamlSection.md")]
-        [InlineData("./TestFiles/YamlSectionOpenedWithExtraCharacters.md")]
-        [InlineData("./TestFiles/YamlSectionClosedWithExtraCharacters.md")]
-        public void GetCreatedDate_YamlContainsNoCreatedDateOrNoValidYaml_ReturnsNullDate(string testFilePath)
-        {
-            // Arrange
-            var testOptions = Options.Create(new FrontMatterOptions());
+    [Theory]
+    [InlineData("./TestFiles/YamlIsEmpty.md")]
+    [InlineData("./TestFiles/YamlContainsOnlyWhitespace.md")]
+    [InlineData("./TestFiles/YamlContainsOnlyNonCreatedDate.md")]
+    [InlineData("./TestFiles/YamlIsMissingBodyIsPresent.md")]
+    [InlineData("./TestFiles/YamlSectionNeverClosed.md")]
+    [InlineData("./TestFiles/YamlSectionNeverOpened.md")]
+    [InlineData("./TestFiles/TextPrecedesYamlSection.md")]
+    [InlineData("./TestFiles/WhitespacePrecedesYamlSection.md")]
+    [InlineData("./TestFiles/YamlSectionOpenedWithExtraCharacters.md")]
+    [InlineData("./TestFiles/YamlSectionClosedWithExtraCharacters.md")]
+    public void GetCreatedDate_YamlContainsNoCreatedDateOrNoValidYaml_ReturnsNullDate(string testFilePath)
+    {
+        // Arrange
+        var testOptions = Options.Create(new FrontMatterOptions());
 
-            // Act
-            var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
-            var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
+        // Act
+        var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
+        var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
 
-            // Assert
-            createdDate.Should().BeNull();
-        }
+        // Assert
+        createdDate.Should().BeNull();
+    }
 
-        [Theory]
-        [InlineData("./TestFiles/YamlContainsOnlyMinCreatedDate.md")]
-        public void GetCreatedDate_YamlContainsMinDate_ReturnsCreatedDate(string testFilePath)
-        {
-            // Arrange
-            var testOptions = Options.Create(new FrontMatterOptions());
-            var expectedDateUtc = DateTime.MinValue;
+    [Theory]
+    [InlineData("./TestFiles/YamlContainsOnlyMinCreatedDate.md")]
+    public void GetCreatedDate_YamlContainsMinDate_ReturnsCreatedDate(string testFilePath)
+    {
+        // Arrange
+        var testOptions = Options.Create(new FrontMatterOptions());
+        var expectedDateUtc = DateTime.MinValue;
 
-            // Act
-            var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
-            var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
+        // Act
+        var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
+        var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
 
-            // Assert
-            createdDate.Should().Be(expectedDateUtc);
-        }
+        // Assert
+        createdDate.Should().Be(expectedDateUtc);
+    }
 
-        [Theory]
-        [InlineData("./TestFiles/YamlContainsOnlyMaxCreatedDate.md")]
-        public void GetCreatedDate_YamlContainsMaxDate_ReturnsCreatedDate(string testFilePath)
-        {
-            // Arrange
-            var testOptions = Options.Create(new FrontMatterOptions());
-            var expectedDateUtc = DateTime.MaxValue;
+    [Theory]
+    [InlineData("./TestFiles/YamlContainsOnlyMaxCreatedDate.md")]
+    public void GetCreatedDate_YamlContainsMaxDate_ReturnsCreatedDate(string testFilePath)
+    {
+        // Arrange
+        var testOptions = Options.Create(new FrontMatterOptions());
+        var expectedDateUtc = DateTime.MaxValue;
 
-            // Act
-            var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
-            var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
+        // Act
+        var markdownFrontMatter = new MarkdownFrontMatter(testOptions);
+        var createdDate = markdownFrontMatter.GetCreatedDateUtc(testFilePath);
 
-            // Assert
-            createdDate.Should().Be(expectedDateUtc);
-        }
+        // Assert
+        createdDate.Should().Be(expectedDateUtc);
+    }
 
-        private void SetTimeZone(string mockTimeZoneId)
-        {
-            var timeZone = TimeZoneInfo.FindSystemTimeZoneById(mockTimeZoneId);
-            var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
-            Debug.Assert(info != null, nameof(info) + " != null");
+    private void SetTimeZone(string mockTimeZoneId)
+    {
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById(mockTimeZoneId);
+        var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
+        Debug.Assert(info != null, nameof(info) + " != null");
 
-            var cachedData = info.GetValue(null);
-            Debug.Assert(cachedData != null, nameof(cachedData) + " != null");
+        var cachedData = info.GetValue(null);
+        Debug.Assert(cachedData != null, nameof(cachedData) + " != null");
 
-            var field = cachedData.GetType().GetField("_localTimeZone",
-                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Instance);
-            Debug.Assert(field != null, nameof(field) + " != null");
+        var field = cachedData.GetType().GetField("_localTimeZone",
+            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Instance);
+        Debug.Assert(field != null, nameof(field) + " != null");
 
-            field.SetValue(cachedData, timeZone);
-        }
+        field.SetValue(cachedData, timeZone);
+    }
 
-        public void Dispose()
-        {
-            TimeZoneInfo.ClearCachedData();
-        }
+    public void Dispose()
+    {
+        TimeZoneInfo.ClearCachedData();
     }
 }


### PR DESCRIPTION
Add a new config section in order to specify a filter to be used when deciding which files should be synchronised.