### PR TITLE
Only run workflow on branch pushes, not tag pushes

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,7 +1,9 @@
 name: Continuous Delivery
 
 on:
-  push: {}
+  push:
+    branches:
+      - "*"
   pull_request: {}
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
There are no functional changes, just a change to stop the workflow running on tag pushes.