### PR TITLE
Add Functional Tests

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -39,6 +39,7 @@ jobs:
         gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
         file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
     - name: Run codacy-coverage-reporter
+      if: matrix.os == 'windows-latest' && github.actor != 'dependabot[bot]'
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
             matrix:
-                os: [windows-latest, macos-latest, ubuntu-latest]
+                os: [windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Build & Test

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -37,13 +37,13 @@ jobs:
         gist_id: 527882e89a938dc78f61a08c300edec4
         gist_description: "code-coverage-${{ github.ref_name }}"
         gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
-        file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
+        file_path: tests/TestResults/Win32NT/badge_shieldsio_linecoverage_green.svg
     - name: Run codacy-coverage-reporter
       if: matrix.os == 'windows-latest' && github.actor != 'dependabot[bot]'
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: tests/TestResults/Cobertura.xml
+        coverage-reports: tests/TestResults/Win32NT/Cobertura.xml
     - name: Build Windows Installer
       if: matrix.os == 'windows-latest'
       run: ./Build/build-windows-installer.ps1

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
             matrix:
-                os: [windows-latest, macos-latest]
+                os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
             matrix:
-                os: [windows-latest, macos-latest]
+                os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -80,11 +80,11 @@ jobs:
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
         files: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
-    - name: Mac OS X Release
+    - name: macOS Release
       uses: softprops/action-gh-release@v1
       if: steps.release-check.outputs.needs-release == 'True' && matrix.os == 'macos-latest'
       with:
         tag_name: v${{ env.GitVersion_SemVer }}
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
-        files: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync osx-x64*.zip
+        files: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -48,6 +48,10 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: ./Build/build-windows-installer.ps1
       shell: pwsh
+    - name: Build OSX Installer
+      if: matrix.os == 'macos-latest'
+      run: ./Build/build-osx-installer.ps1
+      shell: pwsh
     - name: Check for Release Requirement
       id: release-check
       run: |
@@ -76,3 +80,11 @@ jobs:
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
         files: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
+    - name: Mac OS X Release
+      uses: softprops/action-gh-release@v1
+      if: steps.release-check.outputs.needs-release == 'True' && matrix.os == 'macos-latest'
+      with:
+        tag_name: v${{ env.GitVersion_SemVer }}
+        generate_release_notes: true
+        prerelease: ${{ github.ref_name != 'main' }}
+        files: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync osx-x64*.zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
             matrix:
-                os: [windows-latest]
+                os: [windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -38,6 +38,11 @@ jobs:
         gist_description: "code-coverage-${{ github.ref_name }}"
         gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
         file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
+    - name: Run codacy-coverage-reporter
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: tests/TestResults/Cobertura.xml
     - name: Build Windows Installer
       if: matrix.os == 'windows-latest'
       run: ./Build/build-windows-installer.ps1

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -37,13 +37,13 @@ jobs:
         gist_id: 527882e89a938dc78f61a08c300edec4
         gist_description: "code-coverage-${{ github.ref_name }}"
         gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
-        file_path: tests/TestResults/Win32NT/badge_shieldsio_linecoverage_green.svg
+        file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
     - name: Run codacy-coverage-reporter
       if: matrix.os == 'windows-latest' && github.actor != 'dependabot[bot]'
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: tests/TestResults/Win32NT/Cobertura.xml
+        coverage-reports: tests/TestResults/Cobertura.xml
     - name: Build Windows Installer
       if: matrix.os == 'windows-latest'
       run: ./Build/build-windows-installer.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Solution specific items
 /Publish/output
+/tests/TestFiles/Functional

--- a/.gitignore
+++ b/.gitignore
@@ -347,5 +347,6 @@ MigrationBackup/
 .ionide/
 
 # Solution specific items
-/Publish/output
 /tests/TestFiles/Functional
+/Build/Publish 
+/Installer/Elzik.FmSync.OsxInstaller/x64

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell: Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": []
+        }
+    ]
+}

--- a/Build/Test-ExitCode.psm1
+++ b/Build/Test-ExitCode.psm1
@@ -1,0 +1,9 @@
+function Test-ExitCode 
+{
+    if ($LastExitCode -ne 0) 
+    {
+        throw "The previous executable command failed. See console output prior to this message for details."
+    }        
+}
+
+Export-ModuleMember -Function Test-ExitCode

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -1,4 +1,4 @@
-Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
+Import-Module $(Resolve-Path ./Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
@@ -17,7 +17,7 @@ dotnet tool update `
 Test-ExitCode
 
 reportgenerator `
-	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
-	"-targetdir:$repoRootPath/tests/TestResults" `
+	"-reports:${repoRootPath}tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
+	"-targetdir:${repoRootPath}tests/TestResults" `
 	"-reporttypes:Badges;Cobertura"
 Test-ExitCode

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -16,4 +16,4 @@ dotnet tool update `
 reportgenerator `
 	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
 	"-targetdir:$repoRootPath/tests/TestResults" `
-	"-reporttypes:Badges"
+	"-reporttypes:Badges;Cobertura"

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -2,12 +2,13 @@ Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
+$osType = ([System.Environment]::OSVersion).Platform
 
 dotnet test $repoRootPath/Elzik.FmSync.sln `
 	-c Release `
 	--verbosity normal `
 	-p:CollectCoverage=true `
-	-p:CoverletOutput=TestResults/coverage.opencover.xml `
+	-p:CoverletOutput=TestResults/$osType/coverage.opencover.xml `
 	-p:CoverletOutputFormat=opencover
 Test-ExitCode
 
@@ -17,7 +18,7 @@ dotnet tool update `
 Test-ExitCode
 
 reportgenerator `
-	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
-	"-targetdir:$repoRootPath/tests/TestResults" `
+	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/$osType/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/$osType/coverage.opencover.xml;" `
+	"-targetdir:$repoRootPath/tests/TestResults/$osType" `
 	"-reporttypes:Badges;Cobertura"
 Test-ExitCode

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -1,7 +1,8 @@
-Import-Module $(Resolve-Path ./Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
+
+Import-Module $(Resolve-Path "$repoRootPath/Build/Test-ExitCode.psm1")
 
 dotnet test $repoRootPath/Elzik.FmSync.sln `
 	-c Release `

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -1,3 +1,4 @@
+Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
@@ -8,12 +9,15 @@ dotnet test $repoRootPath/Elzik.FmSync.sln `
 	-p:CollectCoverage=true `
 	-p:CoverletOutput=TestResults/coverage.opencover.xml `
 	-p:CoverletOutputFormat=opencover
+Test-ExitCode
 
 dotnet tool update `
 	--global dotnet-reportgenerator-globaltool `
 	--version 5.1.8
+Test-ExitCode
 
 reportgenerator `
 	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
 	"-targetdir:$repoRootPath/tests/TestResults" `
 	"-reporttypes:Badges;Cobertura"
+Test-ExitCode

--- a/Build/build-and-test.ps1
+++ b/Build/build-and-test.ps1
@@ -2,13 +2,12 @@ Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
-$osType = ([System.Environment]::OSVersion).Platform
 
 dotnet test $repoRootPath/Elzik.FmSync.sln `
 	-c Release `
 	--verbosity normal `
 	-p:CollectCoverage=true `
-	-p:CoverletOutput=TestResults/$osType/coverage.opencover.xml `
+	-p:CoverletOutput=TestResults/coverage.opencover.xml `
 	-p:CoverletOutputFormat=opencover
 Test-ExitCode
 
@@ -18,7 +17,7 @@ dotnet tool update `
 Test-ExitCode
 
 reportgenerator `
-	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/$osType/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/$osType/coverage.opencover.xml;" `
-	"-targetdir:$repoRootPath/tests/TestResults/$osType" `
+	"-reports:$repoRootPath/tests/Elzik.FmSync.Application.Tests.Unit/TestResults/coverage.opencover.xml;$repoRootPath/tests/Elzik.FmSync.Infrastructure.Tests.Integration/TestResults/coverage.opencover.xml;" `
+	"-targetdir:$repoRootPath/tests/TestResults" `
 	"-reporttypes:Badges;Cobertura"
 Test-ExitCode

--- a/Build/build-osx-installer.ps1
+++ b/Build/build-osx-installer.ps1
@@ -1,0 +1,80 @@
+$ErrorActionPreference = "Stop"
+
+$repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
+$releasePath = "$repoRootPath/Installer/Elzik.FmSync.OsxInstaller/x64/Release/"
+$consolePublishSourcePath = "$repoRootPath/src/Elzik.FmSync.Console/bin/x64/Release/net8.0/osx-x64/publish"
+$workerPublishSourcePath = "$repoRootPath/src/Elzik.FmSync.Worker/bin/x64/Release/net8.0/osx-x64/publish"
+
+If((Test-Path -PathType container "$releasePath"))
+{
+	Remove-Item -Recurse -Path "$releasePath"
+}
+
+Import-Module $(Resolve-Path "$repoRootPath/Build/Test-ExitCode.psm1")
+
+If((Test-Path -PathType container $workerPublishSourcePath))
+{
+	Remove-Item -Recurse -Path $workerPublishSourcePath
+}
+dotnet publish $repoRootPath/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj `
+	--verbosity normal `
+	--runtime osx-x64 `
+	--self-contained true `
+	--configuration Release `
+	-p:Platform=x64 `
+	-p:PublishSingleFile=true
+Test-ExitCode
+
+If((Test-Path -PathType container $consolePublishSourcePath))
+{
+	Remove-Item -Recurse -Path $consolePublishSourcePath
+} 
+dotnet publish $repoRootPath/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj `
+	--verbosity normal `
+	--runtime osx-x64 `
+	--self-contained true `
+	--configuration Release `
+	-p:Platform=x64 `
+	-p:PublishSingleFile=true
+Test-ExitCode
+
+$publishDestinationPath = "$repoRootPath/Build/Publish/osx-x64/"
+
+$consolePublishDestinationPath = "$publishDestinationPath/Console"
+If(!(Test-Path -PathType container $consolePublishDestinationPath))
+{
+	New-Item -ItemType Directory -Path $consolePublishDestinationPath
+}
+Copy-Item "$consolePublishSourcePath/fmsync" `
+	-Destination $consolePublishDestinationPath
+Copy-Item "$consolePublishSourcePath/appSettings.json" `
+	-Destination $consolePublishDestinationPath
+Test-ExitCode
+
+$workerPublishDestinationPath = "$publishDestinationPath/Worker"
+If(!(Test-Path -PathType container $workerPublishDestinationPath))
+{
+	New-Item -ItemType Directory -Path $workerPublishDestinationPath
+}
+Copy-Item "$workerPublishSourcePath/Elzik.FmSync.Worker" `
+	-Destination $workerPublishDestinationPath
+Copy-Item "$workerPublishSourcePath/appSettings.json" `
+	-Destination $workerPublishDestinationPath
+Test-ExitCode
+
+If(!(Test-Path -PathType container $releasePath))
+{
+	New-Item -ItemType Directory -Path $releasePath
+}
+Compress-Archive `
+	-Path "$publishDestinationPath/*" `
+	-DestinationPath "$releasePath/fmsync.zip" `
+	-Force
+Test-ExitCode
+
+dotnet tool update --global GitVersion.Tool
+Test-ExitCode
+
+$SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
+Copy-Item "$releasePath/fmsync.zip" "$releasePath/fmsync osx-x64 v$SemVer.zip"
+Test-ExitCode

--- a/Build/build-osx-installer.ps1
+++ b/Build/build-osx-installer.ps1
@@ -76,5 +76,5 @@ dotnet tool update --global GitVersion.Tool
 Test-ExitCode
 
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
-Copy-Item "$releasePath/fmsync.zip" "$releasePath/fmsync osx-x64 v$SemVer.zip"
+Copy-Item "$releasePath/fmsync.zip" "$releasePath/fmsync-osx-x64-v$SemVer.zip"
 Test-ExitCode

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -5,6 +5,7 @@ $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
 Import-Module $(Resolve-Path "$repoRootPath/Build/Test-ExitCode.psm1")
 
 dotnet publish $repoRootPath\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj `
+	--verbosity normal `
 	--runtime win-x64 `
 	--self-contained true `
 	--configuration Release `
@@ -13,6 +14,7 @@ dotnet publish $repoRootPath\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj 
 Test-ExitCode
 
 dotnet publish $repoRootPath\src\Elzik.FmSync.Console\Elzik.FmSync.Console.csproj `
+	--verbosity normal `
 	--runtime win-x64 `
 	--self-contained true `
 	--configuration Release `
@@ -21,6 +23,7 @@ dotnet publish $repoRootPath\src\Elzik.FmSync.Console\Elzik.FmSync.Console.cspro
 Test-ExitCode
 
 dotnet build $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.WindowsInstaller.wixproj `
+	--verbosity normal `
 	--runtime win-x64 `
 	--self-contained true `
 	--configuration Release `

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -35,5 +35,5 @@ dotnet tool update --global GitVersion.Tool
 Test-ExitCode
 
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
-Copy-Item $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\Elzik.FmSync.WindowsInstaller.msi "$repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\fmsync v$SemVer.msi"
+Copy-Item $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\Elzik.FmSync.WindowsInstaller.msi "$repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\fmsync-win-x64-v$SemVer.msi"
 Test-ExitCode

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -32,5 +32,5 @@ dotnet tool update --global GitVersion.Tool
 Test-ExitCode
 
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
-cp $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\Elzik.FmSync.WindowsInstaller.msi "$repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\fmsync v$SemVer.msi"
+Copy-Item $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\Elzik.FmSync.WindowsInstaller.msi "$repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\fmsync v$SemVer.msi"
 Test-ExitCode

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -1,3 +1,4 @@
+Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
@@ -8,6 +9,7 @@ dotnet publish $repoRootPath\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj 
 	--configuration Release `
 	-p:Platform=x64 `
 	-p:PublishSingleFile=true
+Test-ExitCode
 
 dotnet publish $repoRootPath\src\Elzik.FmSync.Console\Elzik.FmSync.Console.csproj `
 	--runtime win-x64 `
@@ -15,6 +17,7 @@ dotnet publish $repoRootPath\src\Elzik.FmSync.Console\Elzik.FmSync.Console.cspro
 	--configuration Release `
 	-p:Platform=x64 `
 	-p:PublishSingleFile=true
+Test-ExitCode
 
 dotnet build $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.WindowsInstaller.wixproj `
 	--runtime win-x64 `
@@ -22,7 +25,11 @@ dotnet build $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.
 	--configuration Release `
 	-p:Platform=x64 `
 	-p:PublishSingleFile=true
+Test-ExitCode
 
 dotnet tool update --global GitVersion.Tool
+Test-ExitCode
+
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
 cp $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\Elzik.FmSync.WindowsInstaller.msi "$repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\bin\x64\Release\en-US\fmsync v$SemVer.msi"
+Test-ExitCode

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -1,7 +1,8 @@
-Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 $repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
+
+Import-Module $(Resolve-Path "$repoRootPath/Build/Test-ExitCode.psm1")
 
 dotnet publish $repoRootPath\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj `
 	--runtime win-x64 `

--- a/Build/local-pipeline.ps1
+++ b/Build/local-pipeline.ps1
@@ -1,5 +1,8 @@
-Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
+
+$repoRootPath = (Resolve-Path "$PSScriptRoot/../").Path
+
+Import-Module $(Resolve-Path "$repoRootPath/Build/Test-ExitCode.psm1")
 
 & $PSScriptRoot/build-and-test.ps1
 Test-ExitCode

--- a/Build/local-pipeline.ps1
+++ b/Build/local-pipeline.ps1
@@ -1,4 +1,7 @@
+Import-Module $(Resolve-Path ./Build/Test-ExitCode.psm1)
 $ErrorActionPreference = "Stop"
 
 & $PSScriptRoot/build-and-test.ps1
+Test-ExitCode
 & $PSScriptRoot/build-windows-installer.ps1
+Test-ExitCode

--- a/Build/set-platform-specific-config.ps1
+++ b/Build/set-platform-specific-config.ps1
@@ -1,0 +1,20 @@
+Param(
+    [Parameter(Mandatory=$True)]
+    [String] $outputDirectory,
+    [Parameter(Mandatory=$True)]
+    [String] $operatingSystem
+)
+
+if ($operatingSystem -eq 'Windows_NT')
+{
+    $platformSpecificLogPath = 'C:/ProgramData/Elzik/fmsync'
+}
+else
+{
+    $platformSpecificLogPath = '~/Library/Logs/Elzik/fmsync'
+}
+
+$appSettingsPath = "$outputDirectory/appSettings.json"
+
+(Get-Content $appSettingsPath).Replace('[PLATFORM_SPECIFIC_LOG_PATH]', $platformSpecificLogPath) `
+    | Set-Content $appSettingsPath

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
 		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
+		Build\set-platform-specific-config.ps1 = Build\set-platform-specific-config.ps1
 		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection
 EndProject
@@ -39,7 +40,7 @@ Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "Elzik.FmSync.WindowsInstall
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elzik.FmSync.Worker.Tests.Functional", "tests\Elzik.FmSync.Worker.Tests.Functional\Elzik.FmSync.Worker.Tests.Functional.csproj", "{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elzik.FmSync.Console.Tests.Functional", "tests\Elzik.FmSync.Console.Tests.Functional\Elzik.FmSync.Console.Tests.Functional.csproj", "{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elzik.FmSync.Console.Tests.Functional", "tests\Elzik.FmSync.Console.Tests.Functional\Elzik.FmSync.Console.Tests.Functional.csproj", "{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
+		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{069FD2C8-3AFB-4D61-A19A-3257331FC223}"

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{
 EndProject
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "Elzik.FmSync.WindowsInstaller", "Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.WindowsInstaller.wixproj", "{534679A3-D29B-4D63-882B-C09F4D0EA8CB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elzik.FmSync.Worker.Tests.Functional", "tests\Elzik.FmSync.Worker.Tests.Functional\Elzik.FmSync.Worker.Tests.Functional.csproj", "{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -173,6 +175,22 @@ Global
 		{534679A3-D29B-4D63-882B-C09F4D0EA8CB}.Release|x64.Build.0 = Release|x64
 		{534679A3-D29B-4D63-882B-C09F4D0EA8CB}.Release|x86.ActiveCfg = Release|x86
 		{534679A3-D29B-4D63-882B-C09F4D0EA8CB}.Release|x86.Build.0 = Release|x86
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|ARM64.Build.0 = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x64.Build.0 = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -181,6 +199,7 @@ Global
 		{1367919E-184E-4550-B8BB-ECB37C056594} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
 		{A3BB6C79-4D8F-4515-92B5-F169F929AF94} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
 		{534679A3-D29B-4D63-882B-C09F4D0EA8CB} = {069FD2C8-3AFB-4D61-A19A-3257331FC223}
+		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87997352-098C-46F7-8BDC-29A370A780DB}

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 	ProjectSection(SolutionItems) = preProject
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
+		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
 		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection
@@ -37,6 +38,8 @@ EndProject
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "Elzik.FmSync.WindowsInstaller", "Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.WindowsInstaller.wixproj", "{534679A3-D29B-4D63-882B-C09F4D0EA8CB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elzik.FmSync.Worker.Tests.Functional", "tests\Elzik.FmSync.Worker.Tests.Functional\Elzik.FmSync.Worker.Tests.Functional.csproj", "{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elzik.FmSync.Console.Tests.Functional", "tests\Elzik.FmSync.Console.Tests.Functional\Elzik.FmSync.Console.Tests.Functional.csproj", "{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -192,6 +195,22 @@ Global
 		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x64.Build.0 = Release|Any CPU
 		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x86.ActiveCfg = Release|Any CPU
 		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B}.Release|x86.Build.0 = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Debug|x86.Build.0 = Debug|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|ARM64.Build.0 = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|x64.Build.0 = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -201,6 +220,7 @@ Global
 		{A3BB6C79-4D8F-4515-92B5-F169F929AF94} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
 		{534679A3-D29B-4D63-882B-C09F4D0EA8CB} = {069FD2C8-3AFB-4D61-A19A-3257331FC223}
 		{B38B9BF5-29FF-44C2-B243-CC5D548B1C6B} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
+		{EF3D7FC2-FE10-4D23-8751-5E60ED9DCEC6} = {CF17A395-4536-42A5-B10B-D2D8EC602BC3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {87997352-098C-46F7-8BDC-29A370A780DB}

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -27,11 +27,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0-BDDF-4291-9BDD-A6D512610FAE}"
 	ProjectSection(SolutionItems) = preProject
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
-		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
 		Build\build-osx-installer.ps1 = Build\build-osx-installer.ps1
+		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
 		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
-		Test-ExitCode.psm1 = Test-ExitCode.psm1
+		Build\set-platform-specific-config.ps1 = Build\set-platform-specific-config.ps1
+		Build\Test-ExitCode.psm1 = Build\Test-ExitCode.psm1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{069FD2C8-3AFB-4D61-A19A-3257331FC223}"

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -28,10 +28,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 	ProjectSection(SolutionItems) = preProject
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
+		Build\build-osx-installer.ps1 = Build\build-osx-installer.ps1
 		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
-		Build\set-platform-specific-config.ps1 = Build\set-platform-specific-config.ps1
-		Build\Test-ExitCode.psm1 = Build\Test-ExitCode.psm1
+		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{069FD2C8-3AFB-4D61-A19A-3257331FC223}"

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 	ProjectSection(SolutionItems) = preProject
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
+		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
 		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -28,7 +28,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 	ProjectSection(SolutionItems) = preProject
 		Build\build-and-test.ps1 = Build\build-and-test.ps1
 		Build\build-windows-installer.ps1 = Build\build-windows-installer.ps1
-		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
 		Test-ExitCode.psm1 = Test-ExitCode.psm1
 	EndProjectSection

--- a/Elzik.FmSync.sln
+++ b/Elzik.FmSync.sln
@@ -31,7 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0FE56BA0
 		.github\workflows\continuous-delivery.yml = .github\workflows\continuous-delivery.yml
 		Build\local-pipeline.ps1 = Build\local-pipeline.ps1
 		Build\set-platform-specific-config.ps1 = Build\set-platform-specific-config.ps1
-		Test-ExitCode.psm1 = Test-ExitCode.psm1
+		Build\Test-ExitCode.psm1 = Build\Test-ExitCode.psm1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{069FD2C8-3AFB-4D61-A19A-3257331FC223}"

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The [latest Windows MSI release is always available here](https://github.com/elz
 
 Download and run the MSI file. By default, it will install the command line tools as well as a Windows service.
 
+### Mac
+
+This repo includes a build for macOS and all tests pass including functional tests running on a macOS VM. So, I am confident that this _can_ work on a Mac. However, I do not have a Mac and I have never tried fmsync on macOS nor have I packaged it up into any form of installer. It is available as a zipped set of binaries on the [releases page](https://github.com/elzik/fmsync/releases). If someone can validate the binaries released or is able to help with packaging up into some sort of installer, I'd be grateful.
+
 ### Linux
 
 No release available. Whilst this project will compile for Linux, it has been removed from the build workflow and no Linux release is available due to fragmentation across different filesystems and Linux distributions making it difficult or in some cases impossible to get and set a created-date for a file. I am happy to revist this if needs be.
-
-### Mac
-
-No release available. The workflow for this repo does include a build for Mac but I do not have a Mac and I do not know if a created-date is something typically supported by Macs. If someone wanted to get involved in confirming that this will work on a Mac and to give me help packaging it up for release, I'd appreciate it.
 
 ## Command Line
 
@@ -40,7 +40,7 @@ fmsync c:\my-markdownfiles
 
 ### Logging
 
-By default, only Information, Warnings and Errors are logged to both the console and to a file located in `C:\ProgramData\fmsync\Elzik.FmSync.ConsoleYYYYMMDD.log`. A new file will be created for each day that the tool is used and files older than 7 days are removed.
+By default, only Information, Warnings and Errors are logged to both the console and to a file located in `C:\ProgramData\Elzik\fmsync\Elzik.FmSync.ConsoleYYYYMMDD.log` on Windows and `~/Library/Logs/Elzik/fmsync/Elzik.FmSync.ConsoleYYYYMMDD.log` on macOS. A new file will be created for each day that the tool is used and files older than 7 days are removed.
 
 ## Worker Service
 
@@ -50,11 +50,11 @@ After installation, FmSync will be running as a Windows service, watching all of
 
 ### Logging
 
-By default, only Information, Warnings and Errors are logged to both the console (when started on the command line) and to a file located in `C:\ProgramData\fmsync\Elzik.FmSync.WorkerYYYYMMDD.log` (in all circumstances). A new file will be created for each day that the tool is used and files older than 7 days are removed.
+By default, only Information, Warnings and Errors are logged to both the console (only when started on the command line) and to a file located in `C:\ProgramData\Elzik\fmsync\Elzik.FmSync.WorkerYYYYMMDD.log` on Windows and `~/Library/Logs/Elzik/fmsync/Elzik.FmSync.ConsoleYYYYMMDD.log` on macOS. A new file will be created for each day that the tool is used and files older than 7 days are removed.
 
 ## Configuration
 
-FmSync is configured through a separate appSettings.json file for both the command line tool (`C:\Program Files\Elzik\fmsync\CommandLine\appSettings.json` by default) and the service (`C:\Program Files\Elzik\fmsync\Service\appSettings.json` by default) which contains the following sections:
+FmSync is configured through a separate appSettings.json file for both the command line tool (`C:\Program Files\Elzik\fmsync\CommandLine\appSettings.json` by default on Windows) and the service (`C:\Program Files\Elzik\fmsync\Service\appSettings.json` by default on Windows) which contains the following sections:
 
 ### WatcherOptions (Only applicable when running as a service)
 

--- a/src/Elzik.FmSync.Application/Retry5TimesPipelineBuilder.cs
+++ b/src/Elzik.FmSync.Application/Retry5TimesPipelineBuilder.cs
@@ -15,17 +15,11 @@ namespace Elzik.FmSync.Application
                 MaxRetryAttempts = 5,
                 BackoffType = DelayBackoffType.Exponential,
                 ShouldHandle = new PredicateBuilder()
-                    .Handle<IOException>(WhenFileIsInUse)
+                    .Handle<IOException>()
                     .Handle<YamlException>(WithInnerFormatException)
             });
 
             return builder;
-        }
-
-        private static bool WhenFileIsInUse(IOException ex)
-        {
-            // https://stackoverflow.com/a/67144250/1025593
-            return (ex.HResult & 0x0000FFFF) == 32;
         }
 
         private static bool WithInnerFormatException(YamlException arg)

--- a/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
+++ b/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
   </Target>
 
 </Project>

--- a/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
+++ b/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
@@ -5,8 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..</DockerfileContext>
     <RootNamespace>Elzik.FmSync</RootNamespace>
     <AssemblyName>fmsync</AssemblyName>
   </PropertyGroup>

--- a/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
+++ b/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
@@ -41,4 +41,8 @@
     </None>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+  </Target>
+
 </Project>

--- a/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
+++ b/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
   </Target>
 
 </Project>

--- a/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
+++ b/src/Elzik.FmSync.Console/Elzik.FmSync.Console.csproj
@@ -42,7 +42,11 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+    <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+  </Target>
+
+  <Target Name="PostPublish" AfterTargets="Publish">
+	<Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)../../Build/set-platform-specific-config.ps1 $(PublishDir) $(OS)" />
   </Target>
 
 </Project>

--- a/src/Elzik.FmSync.Console/appSettings.json
+++ b/src/Elzik.FmSync.Console/appSettings.json
@@ -13,7 +13,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Console.log",
+          "path": "[PLATFORM_SPECIFIC_LOG_PATH]/Elzik.FmSync.Console.log",
           "rollingInterval": "Day",
           "retainedFileCountLimit": "7"
         }

--- a/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
+++ b/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
@@ -42,4 +42,8 @@
 		<ProjectReference Include="..\Elzik.FmSync.Infrastructure\Elzik.FmSync.Infrastructure.csproj" />
 	</ItemGroup>
 
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	</Target>
+
 </Project>

--- a/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
+++ b/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 	</Target>
 
 </Project>

--- a/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
+++ b/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
@@ -5,7 +5,6 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>dotnet-Elzik.FmSync.Worker-4d67e15b-f529-48cc-919a-3c678579aeb2</UserSecretsId>
-		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'!='Debug'">

--- a/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
+++ b/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
@@ -43,7 +43,11 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	</Target>
+
+	<Target Name="PostPublish" AfterTargets="Publish">
+		<Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)../../Build/set-platform-specific-config.ps1 $(PublishDir) $(OS)	" />
 	</Target>
 
 </Project>

--- a/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
+++ b/src/Elzik.FmSync.Worker/Elzik.FmSync.Worker.csproj
@@ -43,7 +43,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 	</Target>
 
 </Project>

--- a/src/Elzik.FmSync.Worker/FmSyncWorker.cs
+++ b/src/Elzik.FmSync.Worker/FmSyncWorker.cs
@@ -88,8 +88,8 @@ namespace Elzik.FmSync.Worker
 
             if(assemblyAttributes.Length == 0)
             {
-                throw new InvalidOperationException("No custom assemby attrubutes found; " +
-                    "#unable to get informationak version.");
+                throw new InvalidOperationException("No custom assembly attributes found; " +
+                    "unable to get informational version.");
             }
 
             return ((AssemblyInformationalVersionAttribute)assemblyAttributes[0]).InformationalVersion;

--- a/src/Elzik.FmSync.Worker/FmSyncWorker.cs
+++ b/src/Elzik.FmSync.Worker/FmSyncWorker.cs
@@ -2,6 +2,7 @@ using Elzik.FmSync.Application;
 using Elzik.FmSync.Infrastructure;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace Elzik.FmSync.Worker
 {
@@ -33,7 +34,7 @@ namespace Elzik.FmSync.Worker
             }
             catch (Exception ex)
             {
-                _logger.LogCritical(ex, "A problem occured whilst starting the worker. " +
+                _logger.LogCritical(ex, "A problem occurred whilst starting the worker. " +
                     "{ExceptionMessage}", ex.Message);
 
                 throw;
@@ -82,11 +83,16 @@ namespace Elzik.FmSync.Worker
 
         private static string GetProductVersion()
         {
-            var processPath = Environment.ProcessPath 
-                ?? throw new InvalidOperationException("Currently executing process path not found.");
+            var assemblyAttributes = Assembly.GetExecutingAssembly()
+                .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
 
-            return FileVersionInfo.GetVersionInfo(processPath).ProductVersion
-                ?? throw new InvalidOperationException("Currently executing process product version not found.");
+            if(assemblyAttributes.Length == 0)
+            {
+                throw new InvalidOperationException("No custom assemby attrubutes found; " +
+                    "#unable to get informationak version.");
+            }
+
+            return ((AssemblyInformationalVersionAttribute)assemblyAttributes[0]).InformationalVersion;
         }
 
         private void OnCreated(object sender, FileSystemEventArgs e)

--- a/src/Elzik.FmSync.Worker/WatcherOptions.cs
+++ b/src/Elzik.FmSync.Worker/WatcherOptions.cs
@@ -2,6 +2,6 @@
 {
     public class WatcherOptions
     {
-        public IEnumerable<string> WatchedDirectoryPaths { get; set; } = new List<string>();
+        public IEnumerable<string> WatchedDirectoryPaths { get; set; } = [];
     }
 }

--- a/src/Elzik.FmSync.Worker/appSettings.json
+++ b/src/Elzik.FmSync.Worker/appSettings.json
@@ -21,7 +21,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.log",
+          "path": "[PLATFORM_SPECIFIC_LOG_PATH]/Elzik.FmSync.Worker.log",
           "rollingInterval": "Day",
           "retainedFileCountLimit": "7"
         }

--- a/tests/Elzik.FmSync.Application.Tests.Unit/xunit.runner.json
+++ b/tests/Elzik.FmSync.Application.Tests.Unit/xunit.runner.json
@@ -1,5 +1,0 @@
-﻿{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": true,
-  "parallelizeAssembly": true
-}

--- a/tests/Elzik.FmSync.Application.Tests.Unit/xunit.runner.json
+++ b/tests/Elzik.FmSync.Application.Tests.Unit/xunit.runner.json
@@ -1,5 +1,5 @@
 ﻿{
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false,
-  "parallelizeAssembly":  true
+  "parallelizeTestCollections": true,
+  "parallelizeAssembly": true
 }

--- a/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
@@ -63,10 +63,10 @@ namespace Elzik.FmSync.Console.Tests.Functional
             await _consoleProcess.WaitForExitAsync();
 
             // Assert
-            consoleOutputLines.Should().Contain(line => 
-                line.EndsWith($"Synchronising *.md files in {_buildOutputDirectory}".TrimEnd('\\')));
-            consoleOutputLines.Should().Contain(line => 
-                line.Contains("Synchronised 0 files out of a total 0 in "));
+            var expectedWorkingDirectoryLogText = $"Synchronising *.md files in {_buildOutputDirectory}".TrimEnd('\\');
+            _testOutputHelper.WriteLine($"expectedWorkingDirectoryLogText = {expectedWorkingDirectoryLogText}");
+            consoleOutputLines.Should().Contain(line => line.EndsWith(expectedWorkingDirectoryLogText));
+            consoleOutputLines.Should().Contain(line => line.Contains("Synchronised 0 files out of a total 0 in "));
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
@@ -63,7 +63,7 @@ namespace Elzik.FmSync.Console.Tests.Functional
             await _consoleProcess.WaitForExitAsync();
 
             // Assert
-            var expectedWorkingDirectoryLogText = $"Synchronising *.md files in {_buildOutputDirectory}".TrimEnd('\\');
+            var expectedWorkingDirectoryLogText = $"Synchronising *.md files in {_buildOutputDirectory}".TrimEnd('\\','/');
             _testOutputHelper.WriteLine($"expectedWorkingDirectoryLogText = {expectedWorkingDirectoryLogText}");
             consoleOutputLines.Should().Contain(line => line.EndsWith(expectedWorkingDirectoryLogText));
             consoleOutputLines.Should().Contain(line => line.Contains("Synchronised 0 files out of a total 0 in "));

--- a/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Elzik.FmSync.Console.Tests.Functional
+{
+    public class ConsoleTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly Process _consoleProcess;
+        private const string FunctionalTestFilesPath = "../../../../TestFiles/Functional/Console";
+        private readonly string _buildOutputDirectory;
+
+        public ConsoleTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper
+                ?? throw new ArgumentNullException(nameof(testOutputHelper));
+
+            if(AppDomain.CurrentDomain.SetupInformation.ApplicationBase == null)
+            {
+                throw new InvalidOperationException("Unable to find build output directory.");
+            }
+            _buildOutputDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+            KillExistingWorkerProcesses(_buildOutputDirectory);
+
+            var workerFilename = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                       ? "fmsync.exe" : "fmsync";
+            var workerExecutablePath = Path.Join(_buildOutputDirectory, workerFilename);
+            _testOutputHelper.WriteLine("Worker under test: {0}", workerExecutablePath);
+            _consoleProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo(workerExecutablePath)
+                {
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                }
+            };
+            _consoleProcess.OutputDataReceived += OnConsoleDataReceivedLog;
+            _consoleProcess.ErrorDataReceived += OnConsoleDataReceivedLog;
+
+            Directory.CreateDirectory(FunctionalTestFilesPath);
+        }
+        [Fact]
+        public async Task Synchronise_EmptyFolder_LogsToConsole()
+        {
+            // Arrange
+            var consoleOutputLines = new List<string>();
+            _consoleProcess.OutputDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                {
+                    consoleOutputLines.Add(e.Data);
+                }
+            };
+
+            // Act
+            ValidateWorkerStart(_consoleProcess!.Start());
+            _consoleProcess.BeginOutputReadLine();
+            await _consoleProcess.WaitForExitAsync();
+
+            // Assert
+            consoleOutputLines.Should().Contain(line => 
+                line.EndsWith($"Synchronising *.md files in {_buildOutputDirectory}".TrimEnd('\\')));
+            consoleOutputLines.Should().Contain(line => 
+                line.Contains("Synchronised 0 files out of a total 0 in "));
+        }
+
+        private static void KillExistingWorkerProcesses(string? directoryPath)
+        {
+            var testWorkers = Process.GetProcessesByName("Elzik.FmSync.Worker")
+                            .Where(p => p.MainModule!.FileName.StartsWith(directoryPath!));
+
+            foreach (var testWorker in testWorkers)
+            {
+                testWorker.Kill();
+            }
+        }
+
+        private void OnConsoleDataReceivedLog(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data != null)
+            {
+                _testOutputHelper.WriteLine(e.Data);
+            }
+        }
+
+        private static void ValidateWorkerStart(bool workerStartResult)
+        {
+            if (!workerStartResult)
+            {
+                throw new InvalidOperationException("A new functional test Console process was not started.");
+            }
+        }
+    }
+}

--- a/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
@@ -49,7 +49,7 @@ namespace Elzik.FmSync.Console.Tests.Functional
         {
             // Arrange
             var consoleOutputLines = new List<string>();
-            _consoleProcess.OutputDataReceived += (sender, e) =>
+            _consoleProcess.OutputDataReceived += (_, e) =>
             {
                 if (e.Data != null)
                 {

--- a/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/ConsoleTests.cs
@@ -14,7 +14,7 @@ namespace Elzik.FmSync.Console.Tests.Functional
         private readonly Process _consoleProcess;
         private const string FunctionalTestFilesPath = "../../../../TestFiles/Functional/Console";
         private const string LogPath = "C:/ProgramData/Elzik/fmsync/" +
-            "Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Console.log";
+            "Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.log";
         private readonly string _buildOutputDirectory;
 
         public ConsoleTests(ITestOutputHelper testOutputHelper)
@@ -46,7 +46,11 @@ namespace Elzik.FmSync.Console.Tests.Functional
             _consoleProcess.ErrorDataReceived += OnConsoleDataReceivedLog;
 
             Directory.CreateDirectory(FunctionalTestFilesPath);
-            File.Delete(LogPath);
+
+            if (File.Exists(LogPath))
+            {
+                File.Delete(LogPath);
+            }
         }
 
         [Fact]

--- a/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
@@ -11,6 +11,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <Compile Remove="TestResults\**" />
+	  <EmbeddedResource Remove="TestResults\**" />
+	  <None Remove="TestResults\**" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<None Remove="appSettings.json" />
 	</ItemGroup>
 	<ItemGroup>

--- a/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
@@ -1,0 +1,52 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Remove="appSettings.json" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="appSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.msbuild" Version="6.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.20.0.85982">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit.analyzers" Version="1.11.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Elzik.FmSync.Console\Elzik.FmSync.Console.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
@@ -51,7 +51,7 @@
 
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 	</Target>
 
 </Project>

--- a/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
@@ -51,7 +51,7 @@
 
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 	</Target>
 
 </Project>

--- a/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.Tests.Functional.csproj
@@ -49,4 +49,9 @@
 		<ProjectReference Include="..\..\src\Elzik.FmSync.Console\Elzik.FmSync.Console.csproj" />
 	</ItemGroup>
 
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+	  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+	</Target>
+
 </Project>

--- a/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
@@ -13,7 +13,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:/ProgramData/Elzik/fmsync/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.log"
+          "path": "[PLATFORM_SPECIFIC_LOG_PATH]/FunctionalTests/Elzik.FmSync.Console.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
@@ -13,7 +13,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Console.Tests.Functional\\Elzik.FmSync.Console.log"
+          "path": "C:/ProgramData/Elzik/fmsync/Elzik.FmSync.Console.Tests.Functional/Elzik.FmSync.Console.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
@@ -1,0 +1,21 @@
+{
+  "FrontMatterOptions": {
+    "TimeZoneId": ""
+  },
+  "FileSystemOptions": {
+    "FilenamePattern": "*.md"
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Console.log"
+        }
+      }
+    ]
+  }
+}

--- a/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/appSettings.json
@@ -13,7 +13,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Console.log"
+          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Console.Tests.Functional\\Elzik.FmSync.Console.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Console.Tests.Functional/xunit.runner.json
+++ b/tests/Elzik.FmSync.Console.Tests.Functional/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false,
+  "parallelizeAssembly":  true
+}

--- a/tests/Elzik.FmSync.Infrastructure.Tests.Integration/xunit.runner.json
+++ b/tests/Elzik.FmSync.Infrastructure.Tests.Integration/xunit.runner.json
@@ -1,5 +1,0 @@
-﻿{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": true,
-  "parallelizeAssembly": true
-}

--- a/tests/Elzik.FmSync.Infrastructure.Tests.Integration/xunit.runner.json
+++ b/tests/Elzik.FmSync.Infrastructure.Tests.Integration/xunit.runner.json
@@ -1,5 +1,5 @@
 ﻿{
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false,
-  "parallelizeAssembly":  true
+  "parallelizeTestCollections": true,
+  "parallelizeAssembly": true
 }

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -11,6 +11,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <Compile Remove="TestResults\**" />
+	  <EmbeddedResource Remove="TestResults\**" />
+	  <None Remove="TestResults\**" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <None Remove="appSettings.json" />
 	</ItemGroup>
 	<ItemGroup>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -9,9 +9,7 @@
 	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+
 	<ItemGroup>
 	  <None Remove="appSettings.json" />
 	</ItemGroup>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -51,7 +51,7 @@
 
 
 		<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+		  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(ProjectDir)/../../Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 		</Target>
 
 </Project>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -51,7 +51,7 @@
 
 
 		<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+		  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
 		</Target>
 
 </Project>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup>
+	  <None Remove="appSettings.json" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Content Include="appSettings.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+	    <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+	  </Content>
+	</ItemGroup>
+
+		<ItemGroup>
+			<PackageReference Include="coverlet.collector" Version="6.0.1">
+				<PrivateAssets>all</PrivateAssets>
+				<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			</PackageReference>
+			<PackageReference Include="coverlet.msbuild" Version="6.0.1">
+				<PrivateAssets>all</PrivateAssets>
+				<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			</PackageReference>
+			<PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
+			<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+			<PackageReference Include="SonarAnalyzer.CSharp" Version="9.20.0.85982">
+				<PrivateAssets>all</PrivateAssets>
+				<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			</PackageReference>
+			<PackageReference Include="xunit" Version="2.7.0" />
+			<PackageReference Include="xunit.analyzers" Version="1.11.0" />
+			<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+				<PrivateAssets>all</PrivateAssets>
+				<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			</PackageReference>
+		</ItemGroup>
+
+
+		<ItemGroup>
+			<ProjectReference Include="..\..\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj" />
+		</ItemGroup>
+
+</Project>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.Tests.Functional.csproj
@@ -49,4 +49,9 @@
 			<ProjectReference Include="..\..\src\Elzik.FmSync.Worker\Elzik.FmSync.Worker.csproj" />
 		</ItemGroup>
 
+
+		<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		  <Exec Command="PowerShell -NoProfile -ExecutionPolicy unrestricted -file $(SolutionDir)/Build/set-platform-specific-config.ps1 $(OutDir) $(OS)" />
+		</Target>
+
 </Project>

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -14,6 +14,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         private Func<FileSystemEventArgs, bool>? _expectedFileChangeMade;
         private readonly FileSystemWatcher _testFileWatcher;
         private const string FunctionalTestFilesPath = "../../../../TestFiles/Functional/Worker";
+        private const string LogPath = "C:/ProgramData/Elzik/fmsync/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.log";
 
         public WorkerTests(ITestOutputHelper testOutputHelper)
         {
@@ -40,6 +41,11 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             _workerProcess.ErrorDataReceived += OnConsoleDataReceivedLog;
 
             Directory.CreateDirectory(FunctionalTestFilesPath);
+
+            if (File.Exists(LogPath))
+            {
+                File.Delete(LogPath);
+            }
 
             _testFileWatcher = new FileSystemWatcher(FunctionalTestFilesPath, "*.md")
             {

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -179,10 +179,10 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            await using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, true);
+            await using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
 
-            _testOutputHelper.WriteLine("File stream about to go out of scope...");
+            _testOutputHelper.WriteLine("Filestream about to go out of scope...");
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -179,10 +179,12 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            await using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            await Task.Delay(lockForMilliseconds);
+            await using (var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                await Task.Delay(lockForMilliseconds);
+            }
 
-            _testOutputHelper.WriteLine("Filestream about to go out of scope...");
+            _testOutputHelper.WriteLine("Filestream is now out of scope...");
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -86,7 +86,8 @@ namespace Elzik.FmSync.Worker.Tests.Functional
 
             // Assert
             monitoredWorkerProcess.Should().Raise("OutputDataReceived")
-                .WithArgs<DataReceivedEventArgs>(dataReceived => _expectedConsoleOutputReceived(dataReceived));
+                .WithArgs<DataReceivedEventArgs>(dataReceived => _expectedConsoleOutputReceived != null 
+                                                              && _expectedConsoleOutputReceived(dataReceived));
         }
 
         [Fact(Timeout = 10000)]
@@ -199,7 +200,8 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         private void AssertFileWasChanged((string Path, DateTime ExpectedCreatedDate) testFile, IMonitor<FileSystemWatcher> monitoredFileWatcher)
         {
             monitoredFileWatcher.Should().Raise("Changed").
-                WithArgs<FileSystemEventArgs>(fileSystemEvent => _expectedFileChangeMade(fileSystemEvent));
+                WithArgs<FileSystemEventArgs>(fileSystemEvent => _expectedFileChangeMade != null 
+                                                              && _expectedFileChangeMade(fileSystemEvent));
             var testFileInfo = new FileInfo(testFile.Path);
             testFileInfo.CreationTimeUtc.Should().Be(testFile.ExpectedCreatedDate, "the Worker should have updated the created date " +
                 "in response to a file edit");

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -180,7 +180,6 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             _testOutputHelper.WriteLine("Locking file...");
             using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
-            testFileStream.Close();
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -155,7 +155,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             _testOutputHelper.WriteLine("Performing test edit...");
             await File.AppendAllLinesAsync(testFilePath, ["Test edit..."]);
 
-            await LockFileTemporarily(testFilePath, 2000);
+            LockFileTemporarily(testFilePath, 2000);
 
             await _workerProcess.WaitForExitAsync();
 
@@ -175,12 +175,12 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             await Task.Delay(2000);
         }
 
-        private async Task LockFileTemporarily(string path, int lockForMilliseconds)
+        private void LockFileTemporarily(string path, int lockForMilliseconds)
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            await using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, true);
-            await Task.Delay(lockForMilliseconds);
+            using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            Thread.Sleep(lockForMilliseconds);
 
             _testOutputHelper.WriteLine("File stream about to go out of scope...");
         }

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -178,9 +178,9 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         private async Task LockFileTemporarily(string path, int lockForMilliseconds)
         {
             _testOutputHelper.WriteLine("Locking file...");
-            var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
-            testFileStream.Dispose();
+            testFileStream.Close();
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -251,7 +251,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
 
         private static async Task WaitForWorketToStart()
         {
-            await Task.Delay(2000);
+            await Task.Delay(3000);
         }
 
         private async Task LockFileTemporarily(string path, int lockForMilliseconds)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -1,0 +1,78 @@
+﻿using FluentAssertions;
+using System.Diagnostics;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elzik.FmSync.Worker.Tests.Functional
+{
+    public class WorkerTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly Process? _workerProcess;
+        private Func<DataReceivedEventArgs, bool> _validateConsoleOutput;
+
+        public WorkerTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper 
+                ?? throw new ArgumentNullException(nameof(testOutputHelper));
+
+            var outputDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+            var workerExecutablePath = Path.Join(outputDirectory, "Elzik.FmSync.Worker.exe");
+
+            _workerProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo(workerExecutablePath)
+                {
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                }
+            };
+
+            _validateConsoleOutput = (_) => throw new InvalidOperationException(
+                "No console output validation implementation has been supplied.");
+        }
+
+        [Theory(Timeout = 5000)]
+        [InlineData("has started.")]
+        [InlineData("Configuring watcher on ../../../../TestFiles for new and changed *.md files.")]
+        [InlineData("Watcher on ../../../../TestFiles has started.")]
+        [InlineData("A total of 1 directory watchers are running.")]
+        public async Task Test(string expectedLogOutput)
+        {
+            // Arrange
+            _workerProcess!.OutputDataReceived += OnDataReceived;
+            _workerProcess.ErrorDataReceived += OnDataReceived;
+            _validateConsoleOutput = (DataReceivedEventArgs dataReceived) =>
+            {
+                return dataReceived.Data != null && 
+                       dataReceived.Data.EndsWith(expectedLogOutput);
+            };
+            using var monitoredWorkerProcess = _workerProcess.Monitor();
+
+            // Act
+            _workerProcess!.Start();
+            _workerProcess.BeginOutputReadLine();
+            await _workerProcess.WaitForExitAsync();
+
+            // Assert
+            monitoredWorkerProcess.Should().Raise("OutputDataReceived")
+                .WithArgs<DataReceivedEventArgs>(dataReceived =>_validateConsoleOutput(dataReceived));
+        }
+
+        
+        private void OnDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if(e.Data != null)
+            {
+                _testOutputHelper.WriteLine(e.Data!);
+            }
+
+            if(_validateConsoleOutput(e))
+            {
+                _workerProcess!.Kill();
+            }
+        }
+    }
+}

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -179,12 +179,10 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            await using (var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-            {
-                await Task.Delay(lockForMilliseconds);
-            }
+            await using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            await Task.Delay(lockForMilliseconds);
 
-            _testOutputHelper.WriteLine("Filestream is now out of scope...");
+            _testOutputHelper.WriteLine("Filestream about to go out of scope...");
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -179,7 +179,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            await using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
 
             _testOutputHelper.WriteLine("Filestream about to go out of scope...");

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -155,7 +155,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             _testOutputHelper.WriteLine("Performing test edit...");
             await File.AppendAllLinesAsync(testFilePath, ["Test edit..."]);
 
-            LockFileTemporarily(testFilePath, 2000);
+            await LockFileTemporarily(testFilePath, 2000);
 
             await _workerProcess.WaitForExitAsync();
 
@@ -175,12 +175,12 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             await Task.Delay(2000);
         }
 
-        private void LockFileTemporarily(string path, int lockForMilliseconds)
+        private async Task LockFileTemporarily(string path, int lockForMilliseconds)
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            Thread.Sleep(lockForMilliseconds);
+            await using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, true);
+            await Task.Delay(lockForMilliseconds);
 
             _testOutputHelper.WriteLine("File stream about to go out of scope...");
         }

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -123,7 +123,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
 
         }
 
-        [Fact(Timeout = 360000)]
+        [Fact(Timeout = 20000)]
         public async Task FrontMatterIsUpdated_WithNewCreatedDateAndLockedFile_FileCreatedDateIsEventuallyUpdated()
         {
             // Arrange

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -178,8 +178,11 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         private async Task LockFileTemporarily(string path, int lockForMilliseconds)
         {
             _testOutputHelper.WriteLine("Locking file...");
+
             using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
+
+            _testOutputHelper.WriteLine("Filestream about to go out of scope...");
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -179,10 +179,10 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         {
             _testOutputHelper.WriteLine("Locking file...");
 
-            await using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            await using var testFileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, true);
             await Task.Delay(lockForMilliseconds);
 
-            _testOutputHelper.WriteLine("Filestream about to go out of scope...");
+            _testOutputHelper.WriteLine("File stream about to go out of scope...");
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -123,7 +123,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
 
         }
 
-        [Fact(Timeout = 20000)]
+        [Fact(Timeout = 360000)]
         public async Task FrontMatterIsUpdated_WithNewCreatedDateAndLockedFile_FileCreatedDateIsEventuallyUpdated()
         {
             // Arrange

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -178,9 +178,9 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         private async Task LockFileTemporarily(string path, int lockForMilliseconds)
         {
             _testOutputHelper.WriteLine("Locking file...");
-            using var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            var testFileStream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             await Task.Delay(lockForMilliseconds);
-            testFileStream.Close();
+            testFileStream.Dispose();
         }
 
         private static void KillExistingWorkerProcesses(string? directoryPath)

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -19,6 +19,8 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             var outputDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
             var workerExecutablePath = Path.Join(outputDirectory, "Elzik.FmSync.Worker.exe");
 
+            _testOutputHelper.WriteLine("Worker under test: {0}", workerExecutablePath);
+
             _workerProcess = new Process
             {
                 StartInfo = new ProcessStartInfo(workerExecutablePath)
@@ -39,7 +41,7 @@ namespace Elzik.FmSync.Worker.Tests.Functional
         [InlineData("Configuring watcher on ../../../../TestFiles for new and changed *.md files.")]
         [InlineData("Watcher on ../../../../TestFiles has started.")]
         [InlineData("A total of 1 directory watchers are running.")]
-        public async Task Test(string expectedLogOutput)
+        public async Task WorkerIsStarted_ExpectedLogMessagesAreReceived(string expectedLogOutput)
         {
             // Arrange
             _workerProcess!.OutputDataReceived += OnDataReceived;

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -23,7 +23,9 @@ namespace Elzik.FmSync.Worker.Tests.Functional
             var buildOutputDirectory = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
             KillExistingWorkerProcesses(buildOutputDirectory);
 
-            var workerExecutablePath = Path.Join(buildOutputDirectory, "Elzik.FmSync.Worker.exe");      
+            var workerFilename = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                       ? "Elzik.FmSync.Worker.exe" : "Elzik.FmSync.Worker";
+            var workerExecutablePath = Path.Join(buildOutputDirectory, workerFilename);
             _testOutputHelper.WriteLine("Worker under test: {0}", workerExecutablePath);
             _workerProcess = new Process
             {

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/WorkerTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -21,7 +21,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.log",
+          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Worker.log",
           "rollingInterval": "Day",
           "retainedFileCountLimit": "7"
         }

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -18,7 +18,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:/ProgramData/Elzik/fmsync/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.log"
+          "path": "[PLATFORM_SPECIFIC_LOG_PATH]/FunctionalTests/Elzik.FmSync.Worker.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -18,9 +18,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Worker.log",
-          "rollingInterval": "Day",
-          "retainedFileCountLimit": "7"
+          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Worker.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -18,7 +18,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.Tests.Functional\\Elzik.FmSync.Worker.log"
+          "path": "C:/ProgramData/Elzik/fmsync/Elzik.FmSync.Worker.Tests.Functional/Elzik.FmSync.Worker.log"
         }
       }
     ]

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -1,0 +1,31 @@
+{
+  "WatcherOptions": {
+    "WatchedDirectoryPaths": ["../../../../TestFiles"]
+  },
+  "FileSystemOptions": {
+    "FilenamePattern": "*.md"
+  },
+  "FrontMatterOptions": {
+    "TimeZoneId": ""
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Polly": "Warning"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "C:\\ProgramData\\Elzik\\fmsync\\Elzik.FmSync.Worker.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": "7"
+        }
+      }
+    ]
+  }
+}

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/appSettings.json
@@ -11,10 +11,7 @@
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Polly": "Warning"
-      }
+      "Default": "Debug"
     },
     "WriteTo": [
       { "Name": "Console" },

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/xunit.runner.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}

--- a/tests/Elzik.FmSync.Worker.Tests.Functional/xunit.runner.json
+++ b/tests/Elzik.FmSync.Worker.Tests.Functional/xunit.runner.json
@@ -1,5 +1,4 @@
 ﻿{
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false,
-  "parallelizeAssembly":  true
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
- Add end-to-end tests to cover happy paths.
- Include macOS binaries.
- The functional tests showed that retrying _only_ for file system errors where a file was in use did not function on MacOS. To fix this the retries were widened to cover _all_ file system errors.