### PR TITLE
Split Build into Jobs

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,6 +19,11 @@ jobs:
     - name: Check for Release Requirement
       id: release-check
       run: |
+        dotnet tool install --global GitVersion.Tool --version 5.*
+        output=$(dotnet-gitversion)
+        semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
+        export GitVersion_SemVer=$semver
+        echo "GitVersion_SemVer: $GitVersion_SemVer"
         productionFilesChangedCount=$(git diff --name-only HEAD^ HEAD | grep -E 'src/|Installer/' | wc -l)
         echo "$productionFilesChangedCount production source code files have changed"
         productionFilesChanged=$((productionFilesChangedCount > 0))

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -115,7 +115,7 @@ jobs:
         path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
 
   release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: [build-windows, build-macos, check-release-requirement]
     if: needs.check-release-requirement.outputs.needs-release == 'true'
     steps:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -115,6 +115,7 @@ jobs:
     needs: [build-windows, build-macos]
     if: needs.check-release-requirement.outputs.needs-release == 'true'
     steps:
+    - uses: actions/checkout@v4
     - name: Tag With SemVer
       run: |
         git tag "v${{ env.GitVersion_SemVer }}"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -47,92 +47,92 @@ jobs:
       - name: Output needs-release value
         run: echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
 
-  # build-windows:
-  #   runs-on: windows-latest
-  #   needs: check-release-requirement
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0
-  #   - name: Setup .NET
-  #     uses: actions/setup-dotnet@v4
-  #     with:
-  #       dotnet-version: 8.0.x
-  #   - name: Build & Test
-  #     run: ./Build/build-and-test.ps1
-  #     shell: pwsh
-  #   - name: Upload Coverage Badge
-  #     if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
-  #     uses: exuanbo/actions-deploy-gist@v1
-  #     with:
-  #       token: ${{ secrets.CODE_COVERAGE_AUTH_TOKEN }}
-  #       gist_id: 527882e89a938dc78f61a08c300edec4
-  #       gist_description: "code-coverage-${{ github.ref_name }}"
-  #       gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
-  #       file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
-  #   - name: Run codacy-coverage-reporter
-  #     if: github.actor != 'dependabot[bot]'
-  #     uses: codacy/codacy-coverage-reporter-action@v1
-  #     with:
-  #       project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #       coverage-reports: tests/TestResults/Cobertura.xml
-  #   - name: Build Windows Installer
-  #     run: ./Build/build-windows-installer.ps1
-  #     shell: pwsh
-  #   - name: Upload Windows Artifact
-  #     if: steps.release-check.outputs.needs-release == 'True'
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: windows-installer
-  #       path: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
+  build-windows:
+    runs-on: windows-latest
+    needs: check-release-requirement
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Build & Test
+      run: ./Build/build-and-test.ps1
+      shell: pwsh
+    - name: Upload Coverage Badge
+      if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
+      uses: exuanbo/actions-deploy-gist@v1
+      with:
+        token: ${{ secrets.CODE_COVERAGE_AUTH_TOKEN }}
+        gist_id: 527882e89a938dc78f61a08c300edec4
+        gist_description: "code-coverage-${{ github.ref_name }}"
+        gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
+        file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
+    - name: Run codacy-coverage-reporter
+      if: github.actor != 'dependabot[bot]'
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: tests/TestResults/Cobertura.xml
+    - name: Build Windows Installer
+      run: ./Build/build-windows-installer.ps1
+      shell: pwsh
+    - name: Upload Windows Artifact
+      if: steps.release-check.outputs.needs-release == 'True'
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows-installer
+        path: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
 
-  # build-macos:
-  #   runs-on: macos-latest
-  #   needs: check-release-requirement
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0
-  #   - name: Setup .NET
-  #     uses: actions/setup-dotnet@v4
-  #     with:
-  #       dotnet-version: 8.0.x
-  #   - name: Build & Test
-  #     run: ./Build/build-and-test.ps1
-  #     shell: pwsh
-  #   - name: Build OSX Installer
-  #     run: ./Build/build-osx-installer.ps1
-  #     shell: pwsh
-  #   - name: Upload macOS Artifact
-  #     if: steps.release-check.outputs.needs-release == 'True'
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: macos-installer
-  #       path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
+  build-macos:
+    runs-on: macos-latest
+    needs: check-release-requirement
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Build & Test
+      run: ./Build/build-and-test.ps1
+      shell: pwsh
+    - name: Build OSX Installer
+      run: ./Build/build-osx-installer.ps1
+      shell: pwsh
+    - name: Upload macOS Artifact
+      if: steps.release-check.outputs.needs-release == 'True'
+      uses: actions/upload-artifact@v3
+      with:
+        name: macos-installer
+        path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
 
-  # release:
-  #   runs-on: windows-latest
-  #   needs: [build-windows, build-macos]
-  #   if: needs.check-release-requirement.outputs.needs-release == 'true'
-  #   steps:
-  #   - name: Tag With SemVer
-  #     run: |
-  #       git tag "v${{ env.GitVersion_SemVer }}"
-  #       git push --tags
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: windows-installer
-  #       path: ./windows-installer
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: macos-installer
-  #       path: ./macos-installer
-  #   - name: Create Release
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       tag_name: v${{ env.GitVersion_SemVer }}
-  #       generate_release_notes: true
-  #       prerelease: ${{ github.ref_name != 'main' }}
-  #       files: |
-  #         ./windows-installer/fmsync*.msi
-  #         ./macos-installer/fmsync-osx*.zip
+  release:
+    runs-on: windows-latest
+    needs: [build-windows, build-macos]
+    if: needs.check-release-requirement.outputs.needs-release == 'true'
+    steps:
+    - name: Tag With SemVer
+      run: |
+        git tag "v${{ env.GitVersion_SemVer }}"
+        git push --tags
+    - uses: actions/download-artifact@v3
+      with:
+        name: windows-installer
+        path: ./windows-installer
+    - uses: actions/download-artifact@v3
+      with:
+        name: macos-installer
+        path: ./macos-installer
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ env.GitVersion_SemVer }}
+        generate_release_notes: true
+        prerelease: ${{ github.ref_name != 'main' }}
+        files: |
+          ./windows-installer/fmsync*.msi
+          ./macos-installer/fmsync-osx*.zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,7 +19,7 @@ jobs:
     - name: GetSemVer
       id: get-semver
       run: |
-        dotnet tool install --global GitVersion.Tool --version 5.*
+        dotnet tool install --global GitVersion.Tool --version 6.*
         output=$(dotnet-gitversion)
         semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
         export GitVersion_SemVer=$semver

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -80,7 +80,7 @@ jobs:
       run: ./Build/build-windows-installer.ps1
       shell: pwsh
     - name: Upload Windows Artifact
-      if: steps.release-check.outputs.needs-release == 'True'
+      if: needs.check-release-requirement.outputs.needs-release == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: windows-installer
@@ -104,7 +104,7 @@ jobs:
       run: ./Build/build-osx-installer.ps1
       shell: pwsh
     - name: Upload macOS Artifact
-      if: steps.release-check.outputs.needs-release == 'True'
+      if: needs.check-release-requirement.outputs.needs-release == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: macos-installer

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -25,6 +25,7 @@ jobs:
         dotnet tool install --global GitVersion.Tool --version 6.*
         output=$(dotnet-gitversion)
         semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
+        echo $output
         echo "Semantic version: $semver"
         echo "semantic-version=$semver" >> $GITHUB_OUTPUT
     - name: Check for Release Requirement

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -122,6 +122,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Tag With SemVer
       run: |
+        export GitVersion_SemVer=${{ needs.check-release-requirement.outputs.semantic-version }}
         git tag "v${{ needs.check-release-requirement.outputs.semantic-version }}"
         git push --tags
     - uses: actions/download-artifact@v3

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,14 +16,17 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Check for Release Requirement
-      id: release-check
+    - name: GetSemVer
+      id: get-semver
       run: |
         dotnet tool install --global GitVersion.Tool --version 5.*
         output=$(dotnet-gitversion)
         semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
         export GitVersion_SemVer=$semver
         echo "GitVersion_SemVer: $GitVersion_SemVer"
+    - name: Check for Release Requirement
+      id: release-check
+      run: |
         productionFilesChangedCount=$(git diff --name-only HEAD^ HEAD | grep -E 'src/|Installer/' | wc -l)
         echo "$productionFilesChangedCount production source code files have changed"
         productionFilesChanged=$((productionFilesChangedCount > 0))

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -38,69 +38,6 @@ jobs:
         echo "Release will be generated: $needsRelease"
         echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
 
-  build-windows:
-    runs-on: windows-latest
-    needs: check-release-requirement
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-    - name: Build & Test
-      run: ./Build/build-and-test.ps1
-      shell: pwsh
-    - name: Upload Coverage Badge
-      if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
-      uses: exuanbo/actions-deploy-gist@v1
-      with:
-        token: ${{ secrets.CODE_COVERAGE_AUTH_TOKEN }}
-        gist_id: 527882e89a938dc78f61a08c300edec4
-        gist_description: "code-coverage-${{ github.ref_name }}"
-        gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
-        file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
-    - name: Run codacy-coverage-reporter
-      if: github.actor != 'dependabot[bot]'
-      uses: codacy/codacy-coverage-reporter-action@v1
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: tests/TestResults/Cobertura.xml
-    - name: Build Windows Installer
-      run: ./Build/build-windows-installer.ps1
-      shell: pwsh
-    - name: Upload Windows Artifact
-      if: steps.release-check.outputs.needs-release == 'True'
-      uses: actions/upload-artifact@v3
-      with:
-        name: windows-installer
-        path: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
-
-  build-macos:
-    runs-on: macos-latest
-    needs: check-release-requirement
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-    - name: Build & Test
-      run: ./Build/build-and-test.ps1
-      shell: pwsh
-    - name: Build OSX Installer
-      run: ./Build/build-osx-installer.ps1
-      shell: pwsh
-    - name: Upload macOS Artifact
-      if: steps.release-check.outputs.needs-release == 'True'
-      uses: actions/upload-artifact@v3
-      with:
-        name: macos-installer
-        path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
-
   output-needs-release:
     needs: check-release-requirement
     runs-on: ubuntu-latest
@@ -108,29 +45,92 @@ jobs:
       - name: Output needs-release value
         run: echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
 
-  release:
-    runs-on: windows-latest
-    needs: [build-windows, build-macos]
-    if: needs.check-release-requirement.outputs.needs-release == 'true'
-    steps:
-    - name: Tag With SemVer
-      run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
-        git push --tags
-    - uses: actions/download-artifact@v3
-      with:
-        name: windows-installer
-        path: ./windows-installer
-    - uses: actions/download-artifact@v3
-      with:
-        name: macos-installer
-        path: ./macos-installer
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: v${{ env.GitVersion_SemVer }}
-        generate_release_notes: true
-        prerelease: ${{ github.ref_name != 'main' }}
-        files: |
-          ./windows-installer/fmsync*.msi
-          ./macos-installer/fmsync-osx*.zip
+  # build-windows:
+  #   runs-on: windows-latest
+  #   needs: check-release-requirement
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0
+  #   - name: Setup .NET
+  #     uses: actions/setup-dotnet@v4
+  #     with:
+  #       dotnet-version: 8.0.x
+  #   - name: Build & Test
+  #     run: ./Build/build-and-test.ps1
+  #     shell: pwsh
+  #   - name: Upload Coverage Badge
+  #     if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
+  #     uses: exuanbo/actions-deploy-gist@v1
+  #     with:
+  #       token: ${{ secrets.CODE_COVERAGE_AUTH_TOKEN }}
+  #       gist_id: 527882e89a938dc78f61a08c300edec4
+  #       gist_description: "code-coverage-${{ github.ref_name }}"
+  #       gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
+  #       file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
+  #   - name: Run codacy-coverage-reporter
+  #     if: github.actor != 'dependabot[bot]'
+  #     uses: codacy/codacy-coverage-reporter-action@v1
+  #     with:
+  #       project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #       coverage-reports: tests/TestResults/Cobertura.xml
+  #   - name: Build Windows Installer
+  #     run: ./Build/build-windows-installer.ps1
+  #     shell: pwsh
+  #   - name: Upload Windows Artifact
+  #     if: steps.release-check.outputs.needs-release == 'True'
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: windows-installer
+  #       path: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
+
+  # build-macos:
+  #   runs-on: macos-latest
+  #   needs: check-release-requirement
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0
+  #   - name: Setup .NET
+  #     uses: actions/setup-dotnet@v4
+  #     with:
+  #       dotnet-version: 8.0.x
+  #   - name: Build & Test
+  #     run: ./Build/build-and-test.ps1
+  #     shell: pwsh
+  #   - name: Build OSX Installer
+  #     run: ./Build/build-osx-installer.ps1
+  #     shell: pwsh
+  #   - name: Upload macOS Artifact
+  #     if: steps.release-check.outputs.needs-release == 'True'
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: macos-installer
+  #       path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
+
+  # release:
+  #   runs-on: windows-latest
+  #   needs: [build-windows, build-macos]
+  #   if: needs.check-release-requirement.outputs.needs-release == 'true'
+  #   steps:
+  #   - name: Tag With SemVer
+  #     run: |
+  #       git tag "v${{ env.GitVersion_SemVer }}"
+  #       git push --tags
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: windows-installer
+  #       path: ./windows-installer
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: macos-installer
+  #       path: ./macos-installer
+  #   - name: Create Release
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       tag_name: v${{ env.GitVersion_SemVer }}
+  #       generate_release_notes: true
+  #       prerelease: ${{ github.ref_name != 'main' }}
+  #       files: |
+  #         ./windows-installer/fmsync*.msi
+  #         ./macos-installer/fmsync-osx*.zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -104,10 +104,9 @@ jobs:
   release:
     runs-on: windows-latest
     needs: [build-windows, build-macos]
-    if: needs.check-release-requirement.outputs['release-check.needs-release'] == 'True'
+    if: needs.check-release-requirement.outputs.needs-release == 'True'
     steps:
     - name: Tag With SemVer
-      if: steps.release-check.outputs.needs-release == 'True'
       run: |
         git tag "v${{ env.GitVersion_SemVer }}"
         git push --tags

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -116,7 +116,7 @@ jobs:
 
   release:
     runs-on: windows-latest
-    needs: [build-windows, build-macos]
+    needs: [build-windows, build-macos, check-release-requirement]
     if: needs.check-release-requirement.outputs.needs-release == 'true'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,14 +16,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: GetSemVer
-      id: get-semver
-      run: |
-        dotnet tool install --global GitVersion.Tool --version 6.*
-        output=$(dotnet-gitversion)
-        semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
-        export GitVersion_SemVer=$semver
-        echo "GitVersion_SemVer: $GitVersion_SemVer"
     - name: Check for Release Requirement
       id: release-check
       run: |
@@ -37,11 +29,6 @@ jobs:
         needsRelease=$([[ "$forceReleaseRequested" == "true" || ( "$productionFilesChanged" == "1" && "$branchIsMain" == "true" ) ]] && echo true || echo false)
         echo "Release will be generated: $needsRelease"
         echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
-    - name: Tag With SemVer
-      if: steps.release-check.outputs.needs-release == 'True'
-      run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
-        git push --tags
 
   build-windows:
     runs-on: windows-latest
@@ -107,9 +94,22 @@ jobs:
         path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
 
   release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: [build-windows, build-macos]
     steps:
+    - name: GetSemVer
+      id: get-semver
+      run: |
+        dotnet tool install --global GitVersion.Tool --version 6.*
+        output=$(dotnet-gitversion)
+        semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
+        export GitVersion_SemVer=$semver
+        echo "GitVersion_SemVer: $GitVersion_SemVer"
+    - name: Tag With SemVer
+      if: steps.release-check.outputs.needs-release == 'True'
+      run: |
+        git tag "v${{ env.GitVersion_SemVer }}"
+        git push --tags
     - uses: actions/download-artifact@v3
       with:
         name: windows-installer

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -101,6 +101,13 @@ jobs:
         name: macos-installer
         path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
 
+  output-needs-release:
+    needs: check-release-requirement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output needs-release value
+        run: echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
+
   release:
     runs-on: windows-latest
     needs: [build-windows, build-macos]

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -104,7 +104,7 @@ jobs:
   release:
     runs-on: windows-latest
     needs: [build-windows, build-macos]
-    if: needs.check-release-requirement.outputs.needs-release == 'True'
+    if: needs.check-release-requirement.outputs.needs-release == 'true'
     steps:
     - name: Tag With SemVer
       run: |

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Display Job Outputs
         run: |
             echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
-            echo "semantic-version = ${{ needs.get-semver-requirement.outputs.semantic-version }}"
+            echo "semantic-version = ${{ needs.check-release-requirement.outputs.semantic-version }}"
 
   build-windows:
     runs-on: windows-latest
@@ -121,7 +121,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Tag With SemVer
       run: |
-        git tag "v${{ needs.get-semver-requirement.outputs.semantic-version }}"
+        git tag "v${{ needs.check-release-requirement.outputs.semantic-version }}"
         git push --tags
     - uses: actions/download-artifact@v3
       with:
@@ -134,7 +134,7 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ needs.get-semver-requirement.outputs.semantic-version }}
+        tag_name: v${{ needs.check-release-requirement.outputs.semantic-version }}
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
         files: |

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -10,14 +10,34 @@ on:
         description: Force tag & release even when the source branch is not main or no production source files have changed
 
 jobs:
-  continuous-delivery:
+  check-release-requirement:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check for Release Requirement
+      id: release-check
+      run: |
+        productionFilesChangedCount=$(git diff --name-only HEAD^ HEAD | grep -E 'src/|Installer/' | wc -l)
+        echo "$productionFilesChangedCount production source code files have changed"
+        productionFilesChanged=$((productionFilesChangedCount > 0))
+        echo "Git ref: ${{ github.ref_name }}"
+        branchIsMain=$([[ "${{ github.ref_name }}" == "main" ]] && echo true || echo false)
+        forceReleaseRequested=$([[ "${{ github.event.inputs.force-release }}" == "true" ]] && echo true || echo false)
+        echo "Forced release requested: $forceReleaseRequested"
+        needsRelease=$([[ "$forceReleaseRequested" == "true" || ( "$productionFilesChanged" == "1" && "$branchIsMain" == "true" ) ]] && echo true || echo false)
+        echo "Release will be generated: $needsRelease"
+        echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
+    - name: Tag With SemVer
+      if: steps.release-check.outputs.needs-release == 'True'
+      run: |
+        git tag "v${{ env.GitVersion_SemVer }}"
+        git push --tags
 
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-            matrix:
-                os: [windows-latest, macos-latest]
-
+  build-windows:
+    runs-on: windows-latest
+    needs: check-release-requirement
     steps:
     - uses: actions/checkout@v4
       with:
@@ -30,7 +50,7 @@ jobs:
       run: ./Build/build-and-test.ps1
       shell: pwsh
     - name: Upload Coverage Badge
-      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest' && github.actor != 'dependabot[bot]'
+      if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
       uses: exuanbo/actions-deploy-gist@v1
       with:
         token: ${{ secrets.CODE_COVERAGE_AUTH_TOKEN }}
@@ -39,52 +59,64 @@ jobs:
         gist_file_name: fmsync-code-coverage-${{ github.ref_name }}.svg
         file_path: tests/TestResults/badge_shieldsio_linecoverage_green.svg
     - name: Run codacy-coverage-reporter
-      if: matrix.os == 'windows-latest' && github.actor != 'dependabot[bot]'
+      if: github.actor != 'dependabot[bot]'
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: tests/TestResults/Cobertura.xml
     - name: Build Windows Installer
-      if: matrix.os == 'windows-latest'
       run: ./Build/build-windows-installer.ps1
       shell: pwsh
+    - name: Upload Windows Artifact
+      if: steps.release-check.outputs.needs-release == 'True'
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows-installer
+        path: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
+
+  build-macos:
+    runs-on: macos-latest
+    needs: check-release-requirement
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Build & Test
+      run: ./Build/build-and-test.ps1
+      shell: pwsh
     - name: Build OSX Installer
-      if: matrix.os == 'macos-latest'
       run: ./Build/build-osx-installer.ps1
       shell: pwsh
-    - name: Check for Release Requirement
-      id: release-check
-      run: |
-        $productionFilesChangedCount = (git diff --name-only HEAD^ HEAD | Select-String -pattern 'src/*|Installer/').Count
-        Write-Output "$productionFilesChangedCount production source code files have changed"
-        $productionFilesChanged = $productionFilesChangedCount -gt 0
-        Write-Output "Git ref:` ${{ github.ref_name }}"
-        $branchIsMain = "${{ github.ref_name }}" -eq 'main'
-        $forceReleaseRequested = "${{ github.event.inputs.force-release }}" -eq 'true'
-        Write-Output "Forced release requested:` $forceReleaseRequested"
-        $needsRelease = $forceReleaseRequested -or ($productionFilesChanged -and $branchIsMain)
-        Write-Output "Release will be generated:` $needsRelease"
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "needs-release=$needsRelease"
-      shell: pwsh
-    - name: Tag With SemVer
+    - name: Upload macOS Artifact
       if: steps.release-check.outputs.needs-release == 'True'
-      run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
-        git push --tags
-      shell: pwsh
-    - name: Windows Release
+      uses: actions/upload-artifact@v3
+      with:
+        name: macos-installer
+        path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
+
+  release:
+    runs-on: windows-latest
+    needs: [build-windows, build-macos]
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: windows-installer
+        path: ./windows-installer
+    - uses: actions/download-artifact@v3
+      with:
+        name: macos-installer
+        path: ./macos-installer
+    - name: Create Release
       uses: softprops/action-gh-release@v1
-      if: steps.release-check.outputs.needs-release == 'True' && matrix.os == 'windows-latest'
+      if: needs.check-release-requirement.outputs['release-check.needs-release'] == 'True'
       with:
         tag_name: v${{ env.GitVersion_SemVer }}
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
-        files: ./Installer/Elzik.FmSync.WindowsInstaller/bin/x64/Release/en-US/fmsync*.msi
-    - name: macOS Release
-      uses: softprops/action-gh-release@v1
-      if: steps.release-check.outputs.needs-release == 'True' && matrix.os == 'macos-latest'
-      with:
-        tag_name: v${{ env.GitVersion_SemVer }}
-        generate_release_notes: true
-        prerelease: ${{ github.ref_name != 'main' }}
-        files: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
+        files: |
+          ./windows-installer/fmsync*.msi
+          ./macos-installer/fmsync-osx*.zip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -122,7 +122,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Tag With SemVer
       run: |
-        export GitVersion_SemVer=${{ needs.check-release-requirement.outputs.semantic-version }}
         git tag "v${{ needs.check-release-requirement.outputs.semantic-version }}"
         git push --tags
     - uses: actions/download-artifact@v3

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,6 +16,14 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: GetSemVer
+      id: get-semver
+      run: |
+        dotnet tool install --global GitVersion.Tool --version 6.*
+        output=$(dotnet-gitversion)
+        semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
+        export GitVersion_SemVer=$semver
+        echo "GitVersion_SemVer: $GitVersion_SemVer"
     - name: Check for Release Requirement
       id: release-check
       run: |
@@ -29,6 +37,11 @@ jobs:
         needsRelease=$([[ "$forceReleaseRequested" == "true" || ( "$productionFilesChanged" == "1" && "$branchIsMain" == "true" ) ]] && echo true || echo false)
         echo "Release will be generated: $needsRelease"
         echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
+    - name: Tag With SemVer
+      if: steps.release-check.outputs.needs-release == 'True'
+      run: |
+        git tag "v${{ env.GitVersion_SemVer }}"
+        git push --tags
 
   build-windows:
     runs-on: windows-latest
@@ -94,22 +107,9 @@ jobs:
         path: ./Installer/Elzik.FmSync.OsxInstaller/x64/Release/fmsync-osx*.zip
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: [build-windows, build-macos]
     steps:
-    - name: GetSemVer
-      id: get-semver
-      run: |
-        dotnet tool install --global GitVersion.Tool --version 6.*
-        output=$(dotnet-gitversion)
-        semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
-        export GitVersion_SemVer=$semver
-        echo "GitVersion_SemVer: $GitVersion_SemVer"
-    - name: Tag With SemVer
-      if: steps.release-check.outputs.needs-release == 'True'
-      run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
-        git push --tags
     - uses: actions/download-artifact@v3
       with:
         name: windows-installer

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -37,11 +37,6 @@ jobs:
         needsRelease=$([[ "$forceReleaseRequested" == "true" || ( "$productionFilesChanged" == "1" && "$branchIsMain" == "true" ) ]] && echo true || echo false)
         echo "Release will be generated: $needsRelease"
         echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
-    - name: Tag With SemVer
-      if: steps.release-check.outputs.needs-release == 'True'
-      run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
-        git push --tags
 
   build-windows:
     runs-on: windows-latest
@@ -109,7 +104,13 @@ jobs:
   release:
     runs-on: windows-latest
     needs: [build-windows, build-macos]
+    if: needs.check-release-requirement.outputs['release-check.needs-release'] == 'True'
     steps:
+    - name: Tag With SemVer
+      if: steps.release-check.outputs.needs-release == 'True'
+      run: |
+        git tag "v${{ env.GitVersion_SemVer }}"
+        git push --tags
     - uses: actions/download-artifact@v3
       with:
         name: windows-installer
@@ -120,7 +121,6 @@ jobs:
         path: ./macos-installer
     - name: Create Release
       uses: softprops/action-gh-release@v1
-      if: needs.check-release-requirement.outputs['release-check.needs-release'] == 'True'
       with:
         tag_name: v${{ env.GitVersion_SemVer }}
         generate_release_notes: true

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needs-release: ${{ steps.release-check.outputs.needs-release }}
+      semantic-version: ${{ steps.get-semver.outputs.semantic-version }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,8 +25,7 @@ jobs:
         dotnet tool install --global GitVersion.Tool --version 6.*
         output=$(dotnet-gitversion)
         semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
-        export GitVersion_SemVer=$semver
-        echo "GitVersion_SemVer: $GitVersion_SemVer"
+        echo "semantic-version=$semver" >> $GITHUB_OUTPUT
     - name: Check for Release Requirement
       id: release-check
       run: |
@@ -45,7 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Output needs-release value
-        run: echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
+        run: |
+            echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
+            echo "semantic-version = ${{ needs.get-semver-requirement.outputs.semantic-version }}"
 
   build-windows:
     runs-on: windows-latest
@@ -118,7 +120,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Tag With SemVer
       run: |
-        git tag "v${{ env.GitVersion_SemVer }}"
+        git tag "v${{ needs.get-semver-requirement.outputs.semantic-version }}"
         git push --tags
     - uses: actions/download-artifact@v3
       with:
@@ -131,7 +133,7 @@ jobs:
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ env.GitVersion_SemVer }}
+        tag_name: v${{ needs.get-semver-requirement.outputs.semantic-version }}
         generate_release_notes: true
         prerelease: ${{ github.ref_name != 'main' }}
         files: |

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -25,6 +25,7 @@ jobs:
         dotnet tool install --global GitVersion.Tool --version 6.*
         output=$(dotnet-gitversion)
         semver=$(echo $output | grep -oP '"SemVer"\s*:\s*"\K[^"]+')
+        echo "Semantic version: $semver"
         echo "semantic-version=$semver" >> $GITHUB_OUTPUT
     - name: Check for Release Requirement
       id: release-check
@@ -40,11 +41,11 @@ jobs:
         echo "Release will be generated: $needsRelease"
         echo "needs-release=$needsRelease" >> $GITHUB_OUTPUT
 
-  output-needs-release:
+  display-job-outputs:
     needs: check-release-requirement
     runs-on: ubuntu-latest
     steps:
-      - name: Output needs-release value
+      - name: Display Job Outputs
         run: |
             echo "needs-release = ${{ needs.check-release-requirement.outputs.needs-release }}"
             echo "semantic-version = ${{ needs.get-semver-requirement.outputs.semantic-version }}"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   check-release-requirement:
     runs-on: ubuntu-latest
+    outputs:
+      needs-release: ${{ steps.release-check.outputs.needs-release }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Build/build-osx-installer.ps1
+++ b/Build/build-osx-installer.ps1
@@ -72,7 +72,7 @@ Compress-Archive `
 	-Force
 Test-ExitCode
 
-dotnet tool update --global GitVersion.Tool
+dotnet tool update --global GitVersion.Tool --version 6.*
 Test-ExitCode
 
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer

--- a/Build/build-windows-installer.ps1
+++ b/Build/build-windows-installer.ps1
@@ -31,7 +31,7 @@ dotnet build $repoRootPath\Installer\Elzik.FmSync.WindowsInstaller\Elzik.FmSync.
 	-p:PublishSingleFile=true
 Test-ExitCode
 
-dotnet tool update --global GitVersion.Tool
+dotnet tool update --global GitVersion.Tool --version 6.*
 Test-ExitCode
 
 $SemVer = (dotnet-gitversion | ConvertFrom-Json).SemVer

--- a/Build/tag-with-semver.ps1
+++ b/Build/tag-with-semver.ps1
@@ -1,4 +1,4 @@
-dotnet tool update --global GitVersion.Tool
+dotnet tool update --global GitVersion.Tool  --version 6.*
 
 $semVer = (dotnet-gitversion | ConvertFrom-Json).SemVer
 $tag = "v$semVer"

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,5 @@
-mode: ContinuousDelivery
+mode: ContinuousDeployment
 branches:
   main:
     is-release-branch: true
+    mode: ContinuousDelivery

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-mode: ContinuousDeployment
+mode: ContinuousDelivery
 branches:
   main:
     is-release-branch: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,4 +2,3 @@ mode: ContinuousDeployment
 branches:
   main:
     is-release-branch: true
-    mode: ContinuousDelivery

--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -2,12 +2,13 @@
   <PropertyGroup>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
     <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
+	<GitVersionTargetFramework>net8.0</GitVersionTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="LICENSE.rtf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -7,7 +7,7 @@
     <None Include="LICENSE.rtf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -7,7 +7,7 @@
     <None Include="LICENSE.rtf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Split workflow into jobs, so that release requirement and tagging is a job that the MacOS and Windows builds, can depend on. This avoids an issue where the second OS build would see additional commits that the first OS build would tag. This would cause incorrect SemVer derivation.

Then a final release job can perform a release for both MacOS and Windows at the same time.