### PR TITLE
Update Windows Installer Dependencies

### DIFF
--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
     <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
-	<GitVersionTargetFramework>net8.0</GitVersionTargetFramework>
+    <GitVersionTargetFramework>net8.0</GitVersionTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="LICENSE.rtf" />
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.4" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elzik.FmSync.Console\Elzik.FmSync.Console.csproj" />

--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="WixToolset.Sdk/4.0.4">
+﻿<Project Sdk="WixToolset.Sdk/5.0.2">
   <PropertyGroup>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
     <GenerateGitVersionInformation>false</GenerateGitVersionInformation>

--- a/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
+++ b/Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj
@@ -8,7 +8,7 @@
     <None Include="LICENSE.rtf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
+    <PackageReference Include="GitVersion.MsBuild" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request includes updates to the `Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixproj` file, focusing on upgrading package dependencies to their latest versions.

Dependency updates:

* Updated `GitVersion.MsBuild` package from version `6.0.2` to `6.0.3`. (`[Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixprojL11-R15](diffhunk://#diff-534e0d21e01f4e9c081d2ad0628d41d612b5d0422840df167a036ad792479528L11-R15)`)
* Updated `WixToolset.UI.wixext` package from version `4.0.4` to `5.0.2`. (`[Installer/Elzik.FmSync.WindowsInstaller/Elzik.FmSync.WindowsInstaller.wixprojL11-R15](diffhunk://#diff-534e0d21e01f4e9c081d2ad0628d41d612b5d0422840df167a036ad792479528L11-R15)`)